### PR TITLE
Feat/columns add sitemap

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -98,10 +98,10 @@ export default function Layout({ children }: LayoutProps) {
                   />
                 </picture>
               </Link>
-              <div className="flex items-center space-x-4">
+              <div className="flex items-center space-x-2 text-sm">
                 <Link
                   to="/columns"
-                  className="px-4 py-2 rounded-full text-gray-700 hover:text-gray-900 font-medium"
+                  className="px-1 py-4 rounded-full text-gray-700 hover:text-gray-900 font-medium"
                 >
                   コラム
                 </Link>
@@ -109,7 +109,7 @@ export default function Layout({ children }: LayoutProps) {
                   <>
                     <Link
                       to={`/profile/${user.id}`}
-                      className="px-4 py-2 rounded-full text-gray-700 hover:text-gray-900 font-medium"
+                      className="px-1 py-4 rounded-full text-gray-700 hover:text-gray-900 font-medium"
                     >
                       マイページ
                     </Link>
@@ -118,13 +118,13 @@ export default function Layout({ children }: LayoutProps) {
                   <>
                     <button
                       onClick={handleLoginAction}
-                      className="px-4 py-2 rounded-full text-gray-700 hover:text-gray-900 font-medium"
+                      className="px-1 py-4 rounded-full text-gray-700 hover:text-gray-900 font-medium"
                     >
                       ログイン
                     </button>
                     <button
                       onClick={handleRegisterAction}
-                      className="px-4 py-2 rounded-full bg-gray-800 text-white hover:bg-gray500 font-medium transition-colors"
+                      className="px-3 py-2 rounded-full bg-gray-800 text-white hover:bg-gray500 font-medium transition-colors"
                     >
                       新規登録
                     </button>

--- a/supabase/functions/generate-sitemap/index.ts
+++ b/supabase/functions/generate-sitemap/index.ts
@@ -16,6 +16,11 @@ interface News {
   created_at: string
 }
 
+interface Column {
+  slug: string
+  created_at: string
+}
+
 serve(async (req) => {
   try {
     // 環境変数の確認
@@ -44,6 +49,14 @@ serve(async (req) => {
     
     if (newsError) {
       throw new Error(`newsテーブルの取得に失敗: ${newsError.message}`)
+    }
+
+    const { data: columns, error: columnsError } = await supabaseClient
+      .from('columns')
+      .select('slug, created_at')
+    
+    if (columnsError) {
+      throw new Error(`columnsテーブルの取得に失敗: ${columnsError.message}`)
     }
 
     // サイトマップの生成
@@ -79,6 +92,13 @@ serve(async (req) => {
     <lastmod>${new Date(item.created_at).toISOString().split('T')[0]}</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
+  </url>`).join('')}
+  ${(columns as Column[]).map(item => `
+  <url>
+    <loc>https://cat-link.catnote.tokyo/columns/${item.slug}</loc>
+    <lastmod>${new Date(item.created_at).toISOString().split('T')[0]}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
   </url>`).join('')}
 </urlset>`
 


### PR DESCRIPTION
Closes #16

## 概要
- サイトマップ生成機能に`columns`テーブルのデータを追加

## 変更内容
- `Column`インターフェースの追加
- `columns`テーブルからのデータ取得処理の追加
- サイトマップ生成時にコラムページのURLを追加
  - 更新頻度: weekly
  - 優先度: 0.6
  - 最終更新日: 記事の作成日

## 動作確認
- [x] `columns`テーブルからデータが正しく取得できること
- [x] 生成されたサイトマップにコラムページのURLが含まれていること
- [x] コラムページのURLに正しい更新頻度と優先度が設定されていること
- [x] サイトマップが正しくStorageに保存されること
- [x] エラー発生時に適切なエラーメッセージが表示されること

## 補足事項
- 