### PR TITLE
 published_atが過去のお知らせ・コラムのみ公開する

### DIFF
--- a/src/components/__tests__/News.test.tsx
+++ b/src/components/__tests__/News.test.tsx
@@ -62,9 +62,11 @@ describe('News', () => {
     const mockFrom = vi.fn().mockReturnValue({
       select: vi.fn().mockReturnValue({
         eq: vi.fn().mockReturnValue({
-          order: vi.fn().mockResolvedValue({
-            data: mockNews,
-            error: null,
+          lt: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({
+              data: mockNews,
+              error: null,
+            }),
           }),
         }),
       }),
@@ -84,7 +86,9 @@ describe('News', () => {
     const mockFrom = vi.fn().mockReturnValue({
       select: vi.fn().mockReturnValue({
         eq: vi.fn().mockReturnValue({
-          order: vi.fn().mockReturnValue(new Promise(() => {})),
+          lt: vi.fn().mockReturnValue({
+            order: vi.fn().mockReturnValue(new Promise(() => {})),
+          }),
         }),
       }),
     });
@@ -100,9 +104,11 @@ describe('News', () => {
     const mockFrom = vi.fn().mockReturnValue({
       select: vi.fn().mockReturnValue({
         eq: vi.fn().mockReturnValue({
-          order: vi.fn().mockResolvedValue({
-            data: null,
-            error: new Error('エラーが発生しました'),
+          lt: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({
+              data: null,
+              error: new Error('エラーが発生しました'),
+            }),
           }),
         }),
       }),

--- a/src/pages/Columns.tsx
+++ b/src/pages/Columns.tsx
@@ -18,6 +18,7 @@ export default function Columns() {
       const { data, error } = await supabase
         .from('columns')
         .select('id, title, content, image_url, published_at, slug')
+        .lt('published_at', new Date().toISOString())
         .order('published_at', { ascending: false });
 
       if (error) throw error;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -33,6 +33,7 @@ export default function Home() {
         .from('news')
         .select('*')
         .eq('is_published', true)
+        .lt('published_at', new Date().toISOString())
         .order('published_at', { ascending: false })
         .limit(3);
 
@@ -47,6 +48,7 @@ export default function Home() {
       const { data, error } = await supabase
         .from('columns')
         .select('*')
+        .lt('published_at', new Date().toISOString())
         .order('published_at', { ascending: false })
         .limit(4);
 

--- a/src/pages/News.tsx
+++ b/src/pages/News.tsx
@@ -18,6 +18,7 @@ export default function News() {
         .from('news')
         .select('*')
         .eq('is_published', true)
+        .lt('published_at', new Date().toISOString())
         .order('published_at', { ascending: false });
 
       if (error) throw error;


### PR DESCRIPTION
Closes #25

## 概要
-  published_atが過去のお知らせ(news)・コラム(columns)のみ公開する

## 変更内容
- 一覧表示でレコードを取得する際に、`published_at`が過去のレコードのみを取得するように修正

## 動作確認
- [x] お知らせの一覧画面でpublished_atが過去のお知らせのレコードのみ取得されるこをと確認
- [x] コラムの一覧画面でpublished_atが過去のコラムのレコードのみ取得されるこをと確認

## 補足事項
- なし