### PR TITLE
プロフィールページの閲覧回数をGA4から取得して表示する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,12 @@ BASIC_AUTH_USER=
 BASIC_AUTH_PASSWORD=
 
 # Google Analytics (GA4) トラッキングID
-VITE_GA_TRACKING_ID=
+VITE_GA_TRACKING_ID=G-XXXXXXXXXX
+
+# Google Analytics API credentials for Edge Functions
+GA_PROPERTY_ID=
+GA_CLIENT_EMAIL=
+GA_PRIVATE_KEY=
 
 # Google Search Console 確認メタタグ
 VITE_SEARCH_CONSOLE_VERIFICATION=

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/react-color": "^3.0.13",
         "@vercel/edge": "^1.2.1",
         "cross-fetch": "^4.1.0",
+        "googleapis": "^148.0.0",
         "hammerjs": "^2.0.8",
         "lucide-react": "^0.344.0",
         "qrcode.react": "^4.2.0",
@@ -2617,7 +2618,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
       "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -2995,6 +2995,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.2.0.tgz",
+      "integrity": "sha512-JocpCSOixzy5XFJi2ub6IMmV/G9i8Lrm2lZvwBv9xPdglmZM0ufDVBbjbrfU/zuLvBfD7Bv2eYxz9i+OHTgkew==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3064,6 +3093,12 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -3097,7 +3132,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3111,7 +3145,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3520,7 +3553,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3666,7 +3698,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3683,6 +3714,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.113",
@@ -3781,7 +3821,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3791,7 +3830,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3836,7 +3874,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4496,6 +4533,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4718,7 +4761,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4755,6 +4797,49 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4779,7 +4864,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4804,7 +4888,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -4939,11 +5022,79 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "148.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-148.0.0.tgz",
+      "integrity": "sha512-8PDG5VItm6E1TdZWDqtRrUJSlBcNwz0/MwCa6AL81y/RxPGXJRUwKqGZfCoVX1ZBbfr3I4NkDxBmeTyOAZSWqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4967,6 +5118,19 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/hammerjs": {
@@ -5034,7 +5198,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5063,7 +5226,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5117,7 +5279,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -5558,6 +5719,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -5867,6 +6040,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -5915,6 +6097,27 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -6107,7 +6310,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6210,7 +6412,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/msw": {
@@ -6383,7 +6584,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7036,6 +7236,21 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -7479,6 +7694,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -7638,7 +7873,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7658,7 +7892,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7675,7 +7908,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -7694,7 +7926,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -8544,6 +8775,12 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
     },
     "node_modules/use-sync-external-store": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/react-color": "^3.0.13",
     "@vercel/edge": "^1.2.1",
     "cross-fetch": "^4.1.0",
+    "googleapis": "^148.0.0",
     "hammerjs": "^2.0.8",
     "lucide-react": "^0.344.0",
     "qrcode.react": "^4.2.0",

--- a/src/components/CatCardWithViews.tsx
+++ b/src/components/CatCardWithViews.tsx
@@ -1,8 +1,9 @@
 import { Eye } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import { usePageViewCount } from '../hooks/usePageViewCount';
 
 import CatCard from './CatCard';
+import { usePageViewCount } from '../hooks/usePageViewCount';
+
 import type { Cat } from '../types';
 
 interface CatCardWithViewsProps {
@@ -44,4 +45,4 @@ export default function CatCardWithViews({ cat, isOwnProfile }: CatCardWithViews
       </div>
     </div>
   );
-} 
+}

--- a/src/components/CatCardWithViews.tsx
+++ b/src/components/CatCardWithViews.tsx
@@ -1,6 +1,6 @@
 import { Eye } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { usePageViewCount } from '../hooks/usePageViewCount';
 
 import CatCard from './CatCard';
 import type { Cat } from '../types';
@@ -8,93 +8,6 @@ import type { Cat } from '../types';
 interface CatCardWithViewsProps {
   cat: Cat;
   isOwnProfile?: boolean;
-}
-
-// 猫のプロフィールページのビュー数を取得するためのカスタムフック
-function usePageViewCount(catId: string | undefined) {
-  return useQuery({
-    queryKey: ['pageViews', catId],
-    queryFn: async () => {
-      if (!catId) return null;
-
-      console.log('[DEBUG] ページビュー取得開始', { catId });
-
-      try {
-        console.log('[DEBUG] APIリクエスト準備', { 
-          url: `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/ga-pageviews`,
-          hasAuthToken: !!import.meta.env.VITE_SUPABASE_ANON_KEY
-        });
-
-        const response = await fetch(
-          `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/ga-pageviews`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
-            },
-            body: JSON.stringify({ catId }),
-            // CORSエラー対策
-            mode: 'cors',
-            credentials: 'omit',
-            cache: 'no-cache',
-          }
-        );
-
-        console.log('[DEBUG] APIレスポンス受信', { 
-          status: response.status, 
-          statusText: response.statusText,
-          ok: response.ok,
-          headers: Object.fromEntries([...response.headers])
-        });
-
-        if (!response.ok) {
-          const errorText = await response.text();
-          let errorData = {};
-          
-          try {
-            errorData = JSON.parse(errorText);
-          } catch (e) {
-            console.error('[DEBUG] レスポンスJSONパースエラー', e);
-          }
-          
-          console.error('[DEBUG] ページビュー取得エラー', {
-            status: response.status,
-            statusText: response.statusText,
-            error: errorData,
-            errorText
-          });
-          return 0; // エラー時は0を返す
-        }
-
-        const responseText = await response.text();
-        console.log('[DEBUG] レスポンステキスト', responseText);
-        
-        let data: { pageViews?: number } = {};
-        try {
-          data = JSON.parse(responseText);
-          console.log('[DEBUG] レスポンスデータ', data);
-        } catch (e) {
-          console.error('[DEBUG] JSONパースエラー', e);
-          return 0;
-        }
-        
-        return data.pageViews || 0;
-      } catch (error: unknown) {
-        console.error('[DEBUG] ページビュー取得失敗', {
-          name: error instanceof Error ? error.name : 'Unknown',
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined
-        });
-        return 0; // エラー時は0を返す
-      }
-    },
-    enabled: !!catId,
-    staleTime: 1000 * 60 * 60, // 1時間キャッシュ
-    retry: 1,
-    // エラー時にも以前のデータを表示
-    placeholderData: (prev) => prev,
-  });
 }
 
 export default function CatCardWithViews({ cat, isOwnProfile }: CatCardWithViewsProps) {
@@ -127,7 +40,7 @@ export default function CatCardWithViews({ cat, isOwnProfile }: CatCardWithViews
       {/* ページビュー数の表示 */}
       <div className="mt-1 flex items-center justify-end text-gray-500 text-xs">
         <Eye className="h-3 w-3 mr-1" />
-        <span>月間表示: {pageViewCount || 0}回</span>
+        <span>月間表示: {pageViewCount ?? 0}回</span>
       </div>
     </div>
   );

--- a/src/components/CatCardWithViews.tsx
+++ b/src/components/CatCardWithViews.tsx
@@ -1,0 +1,134 @@
+import { Eye } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+
+import CatCard from './CatCard';
+import type { Cat } from '../types';
+
+interface CatCardWithViewsProps {
+  cat: Cat;
+  isOwnProfile?: boolean;
+}
+
+// 猫のプロフィールページのビュー数を取得するためのカスタムフック
+function usePageViewCount(catId: string | undefined) {
+  return useQuery({
+    queryKey: ['pageViews', catId],
+    queryFn: async () => {
+      if (!catId) return null;
+
+      console.log('[DEBUG] ページビュー取得開始', { catId });
+
+      try {
+        console.log('[DEBUG] APIリクエスト準備', { 
+          url: `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/ga-pageviews`,
+          hasAuthToken: !!import.meta.env.VITE_SUPABASE_ANON_KEY
+        });
+
+        const response = await fetch(
+          `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/ga-pageviews`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+            },
+            body: JSON.stringify({ catId }),
+            // CORSエラー対策
+            mode: 'cors',
+            credentials: 'omit',
+            cache: 'no-cache',
+          }
+        );
+
+        console.log('[DEBUG] APIレスポンス受信', { 
+          status: response.status, 
+          statusText: response.statusText,
+          ok: response.ok,
+          headers: Object.fromEntries([...response.headers])
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          let errorData = {};
+          
+          try {
+            errorData = JSON.parse(errorText);
+          } catch (e) {
+            console.error('[DEBUG] レスポンスJSONパースエラー', e);
+          }
+          
+          console.error('[DEBUG] ページビュー取得エラー', {
+            status: response.status,
+            statusText: response.statusText,
+            error: errorData,
+            errorText
+          });
+          return 0; // エラー時は0を返す
+        }
+
+        const responseText = await response.text();
+        console.log('[DEBUG] レスポンステキスト', responseText);
+        
+        let data: { pageViews?: number } = {};
+        try {
+          data = JSON.parse(responseText);
+          console.log('[DEBUG] レスポンスデータ', data);
+        } catch (e) {
+          console.error('[DEBUG] JSONパースエラー', e);
+          return 0;
+        }
+        
+        return data.pageViews || 0;
+      } catch (error: unknown) {
+        console.error('[DEBUG] ページビュー取得失敗', {
+          name: error instanceof Error ? error.name : 'Unknown',
+          message: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined
+        });
+        return 0; // エラー時は0を返す
+      }
+    },
+    enabled: !!catId,
+    staleTime: 1000 * 60 * 60, // 1時間キャッシュ
+    retry: 1,
+    // エラー時にも以前のデータを表示
+    placeholderData: (prev) => prev,
+  });
+}
+
+export default function CatCardWithViews({ cat, isOwnProfile }: CatCardWithViewsProps) {
+  // 猫のページビュー数を取得
+  const { data: pageViewCount } = usePageViewCount(cat.id);
+
+  return (
+    <div className="group relative">
+      <CatCard
+        cat={cat}
+        actions={
+          isOwnProfile && (
+            <>
+              <Link
+                to={`/cats/${cat.id}/photos`}
+                className="flex-1 px-3 py-2 bg-gray-800 text-white rounded-lg hover:bg-black transition-all text-sm font-medium text-center"
+              >
+                写真を追加
+              </Link>
+              <Link
+                to={`/cats/${cat.id}/edit`}
+                className="flex-1 px-3 py-2 bg-white text-gray-800 border border-gray-300 rounded-lg hover:bg-gray-50 transition-all text-sm font-medium text-center"
+              >
+                編集する
+              </Link>
+            </>
+          )
+        }
+      />
+      {/* ページビュー数の表示 */}
+      <div className="mt-1 flex items-center justify-end text-gray-500 text-xs">
+        <Eye className="h-3 w-3 mr-1" />
+        <span>月間表示: {pageViewCount || 0}回</span>
+      </div>
+    </div>
+  );
+} 

--- a/src/hooks/usePageViewCount.ts
+++ b/src/hooks/usePageViewCount.ts
@@ -12,7 +12,7 @@ export function usePageViewCount(catId: string) {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+              Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
             },
             body: JSON.stringify({ catId }),
           }
@@ -35,4 +35,4 @@ export function usePageViewCount(catId: string) {
     retry: 1,
     placeholderData: 0,
   });
-} 
+}

--- a/src/hooks/usePageViewCount.ts
+++ b/src/hooks/usePageViewCount.ts
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+
+// 猫のプロフィールページのビュー数を取得するためのカスタムフック
+export function usePageViewCount(catId: string) {
+  return useQuery({
+    queryKey: ['pageViews', catId],
+    queryFn: async () => {
+      try {
+        const response = await window.fetch(
+          `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/ga-pageviews`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+            },
+            body: JSON.stringify({ catId }),
+          }
+        );
+
+        if (!response.ok) {
+          console.error('Failed to fetch page views:', response.status, response.statusText);
+          return 0;
+        }
+
+        const data = await response.json();
+        return data.pageViews;
+      } catch (error) {
+        console.error('Error fetching page views:', error);
+        return 0;
+      }
+    },
+    enabled: !!catId,
+    staleTime: 1000 * 60 * 60, // 1時間
+    retry: 1,
+    placeholderData: 0,
+  });
+} 

--- a/src/pages/CatProfile.tsx
+++ b/src/pages/CatProfile.tsx
@@ -104,6 +104,93 @@ const Modal = ({ isOpen, onClose, photo }: ModalProps) => {
   );
 };
 
+// 猫のプロフィールページのビュー数を取得するためのカスタムフック
+function usePageViewCount(catId: string | undefined) {
+  return useQuery({
+    queryKey: ['pageViews', catId],
+    queryFn: async () => {
+      if (!catId) return null;
+
+      console.log('[DEBUG] ページビュー取得開始', { catId });
+
+      try {
+        console.log('[DEBUG] APIリクエスト準備', { 
+          url: `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/ga-pageviews`,
+          hasAuthToken: !!import.meta.env.VITE_SUPABASE_ANON_KEY
+        });
+
+        const response = await fetch(
+          `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/ga-pageviews`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+            },
+            body: JSON.stringify({ catId }),
+            // CORSエラー対策
+            mode: 'cors',
+            credentials: 'omit',
+            cache: 'no-cache',
+          }
+        );
+
+        console.log('[DEBUG] APIレスポンス受信', { 
+          status: response.status, 
+          statusText: response.statusText,
+          ok: response.ok,
+          headers: Object.fromEntries([...response.headers])
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          let errorData = {};
+          
+          try {
+            errorData = JSON.parse(errorText);
+          } catch (e) {
+            console.error('[DEBUG] レスポンスJSONパースエラー', e);
+          }
+          
+          console.error('[DEBUG] ページビュー取得エラー', {
+            status: response.status,
+            statusText: response.statusText,
+            error: errorData,
+            errorText
+          });
+          return 0; // エラー時は0を返す
+        }
+
+        const responseText = await response.text();
+        console.log('[DEBUG] レスポンステキスト', responseText);
+        
+        let data: { pageViews?: number } = {};
+        try {
+          data = JSON.parse(responseText);
+          console.log('[DEBUG] レスポンスデータ', data);
+        } catch (e) {
+          console.error('[DEBUG] JSONパースエラー', e);
+          return 0;
+        }
+        
+        return data.pageViews || 0;
+      } catch (error: unknown) {
+        console.error('[DEBUG] ページビュー取得失敗', {
+          name: error instanceof Error ? error.name : 'Unknown',
+          message: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined
+        });
+        return 0; // エラー時は0を返す
+      }
+    },
+    enabled: !!catId,
+    staleTime: 1000 * 60 * 60, // 1時間キャッシュ
+    retry: 1,
+    // エラー時にも以前のデータを表示
+    placeholderData: (prev) => prev,
+  });
+}
+
 export default function CatProfile() {
   const { id } = useParams<{ id: string }>();
   const { user } = useAuthStore();

--- a/src/pages/CatProfile.tsx
+++ b/src/pages/CatProfile.tsx
@@ -19,6 +19,7 @@ import AuthModal from '../components/auth/AuthModal';
 import OptimizedImage from '../components/OptimizedImage';
 import ShareModal from '../components/ShareModal';
 import { useHeaderFooter } from '../context/HeaderContext';
+import { usePageViewCount } from '../hooks/usePageViewCount';
 import { handleApiError } from '../lib/api';
 import { supabase } from '../lib/supabase';
 import { useAuthStore } from '../store/authStore';
@@ -103,93 +104,6 @@ const Modal = ({ isOpen, onClose, photo }: ModalProps) => {
     document.body
   );
 };
-
-// 猫のプロフィールページのビュー数を取得するためのカスタムフック
-function usePageViewCount(catId: string | undefined) {
-  return useQuery({
-    queryKey: ['pageViews', catId],
-    queryFn: async () => {
-      if (!catId) return null;
-
-      console.log('[DEBUG] ページビュー取得開始', { catId });
-
-      try {
-        console.log('[DEBUG] APIリクエスト準備', { 
-          url: `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/ga-pageviews`,
-          hasAuthToken: !!import.meta.env.VITE_SUPABASE_ANON_KEY
-        });
-
-        const response = await fetch(
-          `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/ga-pageviews`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
-            },
-            body: JSON.stringify({ catId }),
-            // CORSエラー対策
-            mode: 'cors',
-            credentials: 'omit',
-            cache: 'no-cache',
-          }
-        );
-
-        console.log('[DEBUG] APIレスポンス受信', { 
-          status: response.status, 
-          statusText: response.statusText,
-          ok: response.ok,
-          headers: Object.fromEntries([...response.headers])
-        });
-
-        if (!response.ok) {
-          const errorText = await response.text();
-          let errorData = {};
-          
-          try {
-            errorData = JSON.parse(errorText);
-          } catch (e) {
-            console.error('[DEBUG] レスポンスJSONパースエラー', e);
-          }
-          
-          console.error('[DEBUG] ページビュー取得エラー', {
-            status: response.status,
-            statusText: response.statusText,
-            error: errorData,
-            errorText
-          });
-          return 0; // エラー時は0を返す
-        }
-
-        const responseText = await response.text();
-        console.log('[DEBUG] レスポンステキスト', responseText);
-        
-        let data: { pageViews?: number } = {};
-        try {
-          data = JSON.parse(responseText);
-          console.log('[DEBUG] レスポンスデータ', data);
-        } catch (e) {
-          console.error('[DEBUG] JSONパースエラー', e);
-          return 0;
-        }
-        
-        return data.pageViews || 0;
-      } catch (error: unknown) {
-        console.error('[DEBUG] ページビュー取得失敗', {
-          name: error instanceof Error ? error.name : 'Unknown',
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined
-        });
-        return 0; // エラー時は0を返す
-      }
-    },
-    enabled: !!catId,
-    staleTime: 1000 * 60 * 60, // 1時間キャッシュ
-    retry: 1,
-    // エラー時にも以前のデータを表示
-    placeholderData: (prev) => prev,
-  });
-}
 
 export default function CatProfile() {
   const { id } = useParams<{ id: string }>();

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -5,6 +5,7 @@ import { Helmet } from 'react-helmet-async';
 import { useParams, Link } from 'react-router-dom';
 
 import CatCard from '../components/CatCard';
+import CatCardWithViews from '../components/CatCardWithViews';
 import UserSettingsModal from '../components/user/UserSettingsModal';
 import { useFavorites } from '../hooks/useFavorites';
 import { supabase } from '../lib/supabase';
@@ -153,29 +154,7 @@ export default function UserProfile() {
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
               {cats?.map(cat => (
-                <div key={cat.id} className="group relative">
-                  <CatCard
-                    cat={cat}
-                    actions={
-                      isOwnProfile && (
-                        <>
-                          <Link
-                            to={`/cats/${cat.id}/photos`}
-                            className="flex-1 px-3 py-2 bg-gray-800 text-white rounded-lg hover:bg-black transition-all text-sm font-medium text-center"
-                          >
-                            写真を追加
-                          </Link>
-                          <Link
-                            to={`/cats/${cat.id}/edit`}
-                            className="flex-1 px-3 py-2 bg-white text-gray-800 border border-gray-300 rounded-lg hover:bg-gray-50 transition-all text-sm font-medium text-center"
-                          >
-                            編集する
-                          </Link>
-                        </>
-                      )
-                    }
-                  />
-                </div>
+                <CatCardWithViews key={cat.id} cat={cat} isOwnProfile={isOwnProfile} />
               ))}
             </div>
           )}
@@ -189,9 +168,7 @@ export default function UserProfile() {
           </h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             {favoriteCats.map(cat => (
-              <div key={cat.id} className="relative">
-                <CatCard cat={cat} />
-              </div>
+              <CatCardWithViews key={cat.id} cat={cat} />
             ))}
           </div>
         </div>

--- a/supabase/functions/ga-pageviews/index.ts
+++ b/supabase/functions/ga-pageviews/index.ts
@@ -1,0 +1,169 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { create, getNumericDate } from "https://deno.land/x/djwt@v3.0.1/mod.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+// CORSヘッダーの設定
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Max-Age': '86400',
+};
+
+const supabase = createClient(
+  Deno.env.get('SUPABASE_URL') ?? '',
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+);
+
+function pemToDer(pem: string): Uint8Array {
+  const pemContents = pem
+    .replace(/-----BEGIN PRIVATE KEY-----/, '')
+    .replace(/-----END PRIVATE KEY-----/, '')
+    .replace(/\n/g, '');
+  
+  return new Uint8Array(
+    atob(pemContents)
+      .split('')
+      .map(char => char.charCodeAt(0))
+  );
+}
+
+async function getAccessToken(): Promise<string> {
+  const clientEmail = Deno.env.get('GA_CLIENT_EMAIL');
+  const privateKey = Deno.env.get('GA_PRIVATE_KEY')?.replace(/\\n/g, '\n');
+  
+  if (!clientEmail || !privateKey) {
+    throw new Error('Missing credentials');
+  }
+
+  const derKey = pemToDer(privateKey);
+  const key = await crypto.subtle.importKey(
+    'pkcs8',
+    derKey,
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      hash: { name: 'SHA-256' }
+    },
+    true,
+    ['sign']
+  );
+
+  const jwt = await create(
+    { alg: 'RS256', typ: 'JWT' },
+    {
+      iss: clientEmail,
+      scope: 'https://www.googleapis.com/auth/analytics.readonly',
+      aud: 'https://oauth2.googleapis.com/token',
+      exp: getNumericDate(3600),
+      iat: getNumericDate(0)
+    },
+    key
+  );
+
+  const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=${jwt}`,
+  });
+
+  const { access_token } = await tokenResponse.json();
+  return access_token;
+}
+
+// GA4からページビューを取得する関数
+async function getPageViewsFromGA4(catId: string): Promise<number> {
+  const propertyId = Deno.env.get('GA_PROPERTY_ID');
+  if (!propertyId) throw new Error('GA_PROPERTY_ID is not set');
+
+  const accessToken = await getAccessToken();
+  const response = await fetch(
+    `https://analyticsdata.googleapis.com/v1beta/properties/${propertyId}:runReport`,
+    {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        dateRanges: [{ startDate: '30daysAgo', endDate: 'today' }],
+        dimensions: [{ name: 'pagePath' }],
+        metrics: [{ name: 'screenPageViews' }],
+        dimensionFilter: {
+          filter: {
+            fieldName: 'pagePath',
+            stringFilter: {
+              value: `/cats/${catId}`,
+              matchType: 'EXACT',
+            },
+          },
+        },
+      }),
+    }
+  );
+
+  const data = await response.json();
+  return data.rows?.[0]?.metricValues?.[0]?.value ? parseInt(data.rows[0].metricValues[0].value, 10) : 0;
+}
+
+async function getPageViews(catId: string): Promise<{ pageViews: number; cached: boolean }> {
+  // キャッシュからデータを取得
+  const { data: cachedData } = await supabase
+    .from('cache')
+    .select('value, created_at')
+    .eq('key', `pageviews:${catId}`)
+    .single();
+
+  // キャッシュが有効な場合（1時間以内）
+  if (cachedData && Date.now() - new Date(cachedData.created_at).getTime() < 3600000) {
+    return { pageViews: cachedData.value, cached: true };
+  }
+
+  // GA4から新しいデータを取得
+  const pageViews = await getPageViewsFromGA4(catId);
+
+  // キャッシュを更新
+  const now = new Date();
+  const expires = new Date(now.getTime() + 3600000); // 1時間後
+
+  await supabase
+    .from('cache')
+    .upsert({
+      key: `pageviews:${catId}`,
+      value: pageViews,
+      created_at: now.toISOString(),
+      expires_at: expires.toISOString()
+    });
+
+  return { pageViews, cached: false };
+}
+
+// メインのハンドラー関数
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: corsHeaders
+    });
+  }
+
+  try {
+    const { catId } = await req.json();
+    if (!catId) {
+      return new Response(
+        JSON.stringify({ error: 'catId is required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const result = await getPageViews(catId);
+    return new Response(
+      JSON.stringify(result),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: 'Internal server error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+}); 


### PR DESCRIPTION
Closes #26

## 概要
- GA4のページビュー数を取得・表示する機能を実装
- Edge Functionsを使用してGA4 APIからデータを取得
- パフォーマンス向上のためにキャッシュ機能を実装

## 変更内容
- Edge Function `ga-pageviews`の実装
  - GA4 APIを使用してページビュー数を取得
- キャッシュテーブルの作成と実装
  - `cache`テーブルの作成（1時間有効）
  - RLSポリシーの設定
  - 自動削除トリガーの実装
- 環境変数の追加
  - `GA_PROPERTY_ID`
  - `GA_CLIENT_EMAIL`
  - `GA_PRIVATE_KEY`

## 動作確認
- [ ] Edge Functionのデプロイが成功すること
- [ ] GA4からページビュー数が正しく取得できること
- [ ] キャッシュが正しく機能すること（1時間以内は同じ値を返す）

## 補足事項
なし