### PR TITLE
ローカル環境にSupabaseの環境を構築

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 
 # 全サービス起動
 up:
-	@make supabase-start || true
+	@make supabase-start
 	@make docker-up
 
 # コンテナ クリーンアップ
@@ -24,14 +24,12 @@ supabase-start:
 				supabase start --ignore-health-check --exclude vector; \
 			fi; \
 		fi; \
-		sleep 10; \
 	else \
 		if docker info | grep -q "Operating System: Docker Desktop"; then \
 			supabase start --ignore-health-check; \
 		else \
 			supabase start --ignore-health-check --exclude vector; \
 		fi; \
-		sleep 10; \
 	fi
 
 # Dockerコンテナのみ起動

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,63 @@
-# コンテナ操作
+# コンテナビルド
 build:
 	docker compose build
 
+# 全サービス起動
 up:
-	docker compose up
+	@make supabase-start || true
+	@make docker-up
 
+# コンテナ クリーンアップ
+clean:
+	-docker compose down -v
+	-supabase stop
+	-docker volume rm supabase_db_cat_profile supabase_storage_cat_profile supabase_config_cat_profile 2>/dev/null || true
+	-docker system prune -a -f
+
+# Supabaseのみ起動
+supabase-start:
+	@if docker ps -a -q -f "name=supabase_.*_cat_profile" -f "status=exited" | grep -q .; then \
+		if ! docker ps -a -q -f "name=supabase_.*_cat_profile" -f "status=exited" | xargs -r docker start; then \
+			if docker info | grep -q "Operating System: Docker Desktop"; then \
+				supabase start --ignore-health-check; \
+			else \
+				supabase start --ignore-health-check --exclude vector; \
+			fi; \
+		fi; \
+		sleep 10; \
+	else \
+		if docker info | grep -q "Operating System: Docker Desktop"; then \
+			supabase start --ignore-health-check; \
+		else \
+			supabase start --ignore-health-check --exclude vector; \
+		fi; \
+		sleep 10; \
+	fi
+
+# Dockerコンテナのみ起動
+docker-up:
+	docker compose up -d
+
+# サービスの停止（コンテナを削除せず）
+stop:
+	-docker compose stop
+	-docker ps -a | grep supabase_.*_cat_profile | awk '{print $$1}' | xargs -r docker stop
+
+# 全サービス停止＆削除
 down:
-	docker compose down
+	-docker compose down
+	-supabase stop
+
+restart: down clean up
+
+status:
+	docker compose ps
+	docker ps | grep supabase || echo "No Supabase containers running"
+	docker volume ls | grep cat_profile
+
+# Supabaseにデータをリストア
+db-restore:
+	docker exec -i supabase_db_cat_profile psql -U postgres -d postgres < production.sql
 
 app:
 	docker compose exec web bash
@@ -41,4 +92,4 @@ deploy-sitemap:
 deploy-gemini:
 	supabase functions deploy image-to-gemini --no-verify-jwt
 
-.PHONY: build up down app ps logs lint format test test-coverage deploy-ga-pageviews deploy-sitemap deploy-gemini
+.PHONY: build up down restart status app ps logs lint format test test-coverage deploy-ga-pageviews deploy-sitemap deploy-gemini

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### 前提条件
 
 - Docker と Docker Compose がインストールされていること
-- Supabase のアカウントを持っていること
+- Supabase CLIがインストールされていること
 
 ### 環境構築手順
 
@@ -25,18 +25,22 @@ cp .env.example .env
 
 3. **開発環境の起動**
 ```bash
-make build
 make up
 ```
+このコマンドで以下の処理が実行されます：
+- Supabaseサービスの起動（Docker Desktop/Colima環境自動検出）
+- アプリケーションコンテナの起動
 
-4. **データベースのセットアップ**
-- Supabaseのダッシュボードにログイン
-- SQL Editorを開く
-- `schema.sql`の内容をコピーして実行
+4. **データベースのリストア（必要な場合）**
+プロジェクトルートに`production.sql`の名前でダンプファイルを配置して、以下のコマンドを実行してください。
+```bash
+make db-restore
+```
 
-5. **アプリケーションの確認**
+1. **アプリケーションの確認**
 - ブラウザで http://localhost:5173 にアクセス
-- アプリケーションが正常に動作することを確認
+- Supabase Studio: http://localhost:54323
+- Supabase API: http://localhost:54321
 
 ## 開発コマンド
 
@@ -45,9 +49,12 @@ make up
 
 ```bash
 # 開発環境の操作
-make build   # Dockerイメージのビルド
-make up      # コンテナの起動
-make down    # コンテナの停止
+make up      # 全サービス起動（Supabase + アプリケーション）
+make stop    # コンテナの停止（削除せず）
+make down    # コンテナの停止と削除
+make clean   # コンテナとボリュームの完全削除
+make restart # 全環境の再起動（down→clean→up）
+make status  # コンテナとボリュームの状態確認
 make logs    # コンテナのログ確認
 make app     # コンテナ内でのbashシェル起動
 
@@ -58,6 +65,9 @@ make format  # Prettierによるコードフォーマット
 # テスト実行
 make test           # テストの実行
 make test-coverage  # カバレッジレポート付きでテスト実行
+
+# データベース操作
+make db-restore     # データベースの復元
 ```
 
 ### Supabase Edge Functions

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <link rel="preload" href="/images/top/webp/main.webp" as="image" type="image/webp" fetchpriority="high">
     
     <!-- Content Security Policy -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://*.supabase.co; img-src 'self' data: https://www.google-analytics.com https://www.googletagmanager.com https://*.supabase.co; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://*.supabase.co http://127.0.0.1:54321; img-src 'self' data: https://www.google-analytics.com https://www.googletagmanager.com https://*.supabase.co; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self';">
     
     <title>CAT LINK - 愛猫のプロフィールページを簡単に作成・共有</title>
     <meta name="description" content="CAT LINK|愛猫のプロフィールページを簡単に作成・共有できるサービス。写真ギャラリーやSNS連携機能で、大切な思い出を残しましょう。" />

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,308 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "cat_profile"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 15
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+[edge_runtime]
+enabled = true
+# Configure one of the supported request policies: `oneshot`, `per_worker`.
+# Use `oneshot` for hot reload, or `per_worker` for load testing.
+policy = "oneshot"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 1
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"


### PR DESCRIPTION
Closes #33 

## 概要
- Supabaseのローカル環境を構築した
- 上記にともないMakefileとRESDMEを追記・整理した。

## 変更内容
- Supabaseの定義ファイル追加
- Makefileのdockerの起動と一緒にSupabaseを起動するコマンドを追加
  -  起動以外にもbuildやdownのコマンドも追加
  - READMEを修正

## 動作確認
- [x] `make build`に成功すること
- [x] `make up`に成功すること
- [x] `make stop `に成功すること
- [x] `make down `に成功すること

## 補足事項
なし