### PR TITLE
【猫のプロフィールページ】同じ飼い主の別の猫のプロフィールページへの導線を追加

### DIFF
--- a/src/components/OwnerCatsSection.module.css
+++ b/src/components/OwnerCatsSection.module.css
@@ -1,0 +1,10 @@
+.hideScrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+.scrollContainer {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE and Edge */
+  -webkit-overflow-scrolling: touch; /* スムーズスクロール */
+  padding-right: 20px;
+} 

--- a/src/components/OwnerCatsSection.module.css
+++ b/src/components/OwnerCatsSection.module.css
@@ -7,4 +7,4 @@
   -ms-overflow-style: none; /* IE and Edge */
   -webkit-overflow-scrolling: touch; /* スムーズスクロール */
   padding-right: 20px;
-} 
+}

--- a/src/components/OwnerCatsSection.tsx
+++ b/src/components/OwnerCatsSection.tsx
@@ -1,0 +1,81 @@
+import { Link } from 'react-router-dom';
+
+import OptimizedImage from './OptimizedImage';
+
+interface Cat {
+  id: string;
+  name: string;
+  description: string;
+  image_url: string;
+  [key: string]: any; // その他のプロパティ
+}
+
+interface OwnerCatsSectionProps {
+  cats: Cat[];
+  textColor?: string;
+  title?: string;
+}
+
+export default function OwnerCatsSection({ 
+  cats, 
+  textColor = '#000000', 
+  title = '同じ飼い主の猫ちゃん' 
+}: OwnerCatsSectionProps) {
+  if (!cats || cats.length === 0) return null;
+
+  return (
+    <div className="mt-10 px-3">
+      <h2 className="text-lg font-semibold mb-4" style={{ color: textColor }}>{title}</h2>
+      <div 
+        className="overflow-x-auto pb-4 -mx-3 px-3" 
+        style={{ 
+          scrollbarWidth: 'none', /* Firefox */
+          msOverflowStyle: 'none', /* IE and Edge */
+          paddingRight: '20px',
+          WebkitOverflowScrolling: 'touch' /* スムーズスクロール */
+        }}
+      >
+        {/* Chrome, Safari, Opera向けのスクロールバー非表示 */}
+        <style>
+          {`
+            .overflow-x-auto::-webkit-scrollbar {
+              display: none;
+            }
+          `}
+        </style>
+        <div className="flex gap-3">
+          {cats.map(cat => (
+            <div key={cat.id} className="w-[140px] sm:w-[160px] flex-shrink-0">
+              <Link to={`/cats/${cat.id}`} className="block">
+                <div className="bg-white rounded-lg shadow-md overflow-hidden transform transition-all hover:scale-[1.02]">
+                  <div className="aspect-square overflow-hidden">
+                    <OptimizedImage
+                      src={cat.image_url}
+                      alt={cat.name}
+                      width={160}
+                      height={160}
+                      className="w-full h-full object-cover"
+                      decoding="async"
+                      loading="lazy"
+                      options={{ resize: 'fill', quality: 80 }}
+                    />
+                  </div>
+                  <div className="p-2 bg-white">
+                    <h3 className="text-sm font-semibold text-gray-800 truncate">
+                      {cat.name}
+                    </h3>
+                    <div className="h-[2.5rem] overflow-hidden mt-1">
+                      <p className="text-xs text-gray-600 leading-normal line-clamp-2">
+                        {cat.description || '　'}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/src/components/OwnerCatsSection.tsx
+++ b/src/components/OwnerCatsSection.tsx
@@ -16,23 +16,25 @@ interface OwnerCatsSectionProps {
   title?: string;
 }
 
-export default function OwnerCatsSection({ 
-  cats, 
-  textColor = '#000000', 
-  title = '同じ飼い主の猫ちゃん' 
+export default function OwnerCatsSection({
+  cats,
+  textColor = '#000000',
+  title = '同じ飼い主の猫ちゃん',
 }: OwnerCatsSectionProps) {
   if (!cats || cats.length === 0) return null;
 
   return (
     <div className="mt-10 px-3">
-      <h2 className="text-lg font-semibold mb-4" style={{ color: textColor }}>{title}</h2>
-      <div 
-        className="overflow-x-auto pb-4 -mx-3 px-3" 
-        style={{ 
-          scrollbarWidth: 'none', /* Firefox */
-          msOverflowStyle: 'none', /* IE and Edge */
+      <h2 className="text-lg font-semibold mb-4" style={{ color: textColor }}>
+        {title}
+      </h2>
+      <div
+        className="overflow-x-auto pb-4 -mx-3 px-3"
+        style={{
+          scrollbarWidth: 'none' /* Firefox */,
+          msOverflowStyle: 'none' /* IE and Edge */,
           paddingRight: '20px',
-          WebkitOverflowScrolling: 'touch' /* スムーズスクロール */
+          WebkitOverflowScrolling: 'touch' /* スムーズスクロール */,
         }}
       >
         {/* Chrome, Safari, Opera向けのスクロールバー非表示 */}
@@ -61,9 +63,7 @@ export default function OwnerCatsSection({
                     />
                   </div>
                   <div className="p-2 bg-white">
-                    <h3 className="text-sm font-semibold text-gray-800 truncate">
-                      {cat.name}
-                    </h3>
+                    <h3 className="text-sm font-semibold text-gray-800 truncate">{cat.name}</h3>
                     <div className="h-[2.5rem] overflow-hidden mt-1">
                       <p className="text-xs text-gray-600 leading-normal line-clamp-2">
                         {cat.description || '　'}
@@ -78,4 +78,4 @@ export default function OwnerCatsSection({
       </div>
     </div>
   );
-} 
+}

--- a/src/components/OwnerCatsSection.tsx
+++ b/src/components/OwnerCatsSection.tsx
@@ -25,8 +25,10 @@ export default function OwnerCatsSection({
 
   return (
     <div className="mt-10 px-3">
-      <h2 className="text-lg font-semibold mb-4" style={{ color: textColor }}>{title}</h2>
-      <div 
+      <h2 className="text-lg font-semibold mb-4" style={{ color: textColor }}>
+        {title}
+      </h2>
+      <div
         className={`overflow-x-auto pb-4 -mx-3 px-3 ${styles.scrollContainer} ${styles.hideScrollbar}`}
       >
         {/* Chrome, Safari, Opera向けのスクロールバー非表示 */}

--- a/src/components/OwnerCatsSection.tsx
+++ b/src/components/OwnerCatsSection.tsx
@@ -1,13 +1,13 @@
 import { Link } from 'react-router-dom';
 
 import OptimizedImage from './OptimizedImage';
+import styles from './OwnerCatsSection.module.css';
 
 interface Cat {
   id: string;
   name: string;
   description: string;
   image_url: string;
-  [key: string]: any; // その他のプロパティ
 }
 
 interface OwnerCatsSectionProps {
@@ -25,17 +25,9 @@ export default function OwnerCatsSection({
 
   return (
     <div className="mt-10 px-3">
-      <h2 className="text-lg font-semibold mb-4" style={{ color: textColor }}>
-        {title}
-      </h2>
-      <div
-        className="overflow-x-auto pb-4 -mx-3 px-3"
-        style={{
-          scrollbarWidth: 'none' /* Firefox */,
-          msOverflowStyle: 'none' /* IE and Edge */,
-          paddingRight: '20px',
-          WebkitOverflowScrolling: 'touch' /* スムーズスクロール */,
-        }}
+      <h2 className="text-lg font-semibold mb-4" style={{ color: textColor }}>{title}</h2>
+      <div 
+        className={`overflow-x-auto pb-4 -mx-3 px-3 ${styles.scrollContainer} ${styles.hideScrollbar}`}
       >
         {/* Chrome, Safari, Opera向けのスクロールバー非表示 */}
         <style>

--- a/src/pages/CatProfile.tsx
+++ b/src/pages/CatProfile.tsx
@@ -529,6 +529,9 @@ export default function CatProfile() {
           )}
         </div>
 
+        {/* 同じ飼い主の猫 */}
+        <OwnerCatsSection cats={ownerCats || []} textColor={textColor} />
+
         <div
           className="text-center mt-20 h-[80px] min-h-[80px] flex flex-col items-center justify-center"
           style={{ contentVisibility: 'auto', containIntrinsicSize: '0 80px' }}


### PR DESCRIPTION
Closes #29 

## 概要
- 猫のプロフィールページ下部に、同じ飼い主の別の猫のプロフィールページへの導線を追加しました。

## 変更内容
- プロフィールページ下部に猫のカードを追加
- カードを押下すると別の猫のプロフィールページへ遷移する

## 動作確認
- [x] プロフィールページに、同じ飼い主の別の猫のカードが表示されること
- [x] カードを押下すると別の猫のプロフィールページへ遷移すること

## 補足事項
なし