### PR TITLE
ローカル環境でもSupabase Storageを許可するように修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <link rel="preload" href="/images/top/webp/main.webp" as="image" type="image/webp" fetchpriority="high">
     
     <!-- Content Security Policy -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://*.supabase.co http://127.0.0.1:54321; img-src 'self' data: https://www.google-analytics.com https://www.googletagmanager.com https://*.supabase.co; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://*.supabase.co http://127.0.0.1:54321; img-src 'self' data: https://www.google-analytics.com https://www.googletagmanager.com https://*.supabase.co http://127.0.0.1:54321; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self';">
     
     <title>CAT LINK - 愛猫のプロフィールページを簡単に作成・共有</title>
     <meta name="description" content="CAT LINK|愛猫のプロフィールページを簡単に作成・共有できるサービス。写真ギャラリーやSNS連携機能で、大切な思い出を残しましょう。" />


### PR DESCRIPTION
Closes #39 

## 概要
- ローカル開発環境でSupabase Storageからの画像読み込みエラーを修正

## 変更内容
- Content Security Policy（CSP）の`img-src`ディレクティブに`http://127.0.0.1:54321`を追加
- これにより、ローカル開発環境でSupabase Storageから画像を読み込めるようになる

## 動作確認
- [x] ローカル開発環境でSupabase Storageの画像が正常に表示される
- [x] CSP関連のエラーがコンソールに表示されない

## 補足事項
- CSPのセキュリティを維持しながら、ローカル開発環境での利便性を向上させる修正です
- 本修正はローカル開発環境のみに影響し、本番環境には影響しません