### PR TITLE
Feat/cat show setting

### DIFF
--- a/src/components/CatCardWithViews.tsx
+++ b/src/components/CatCardWithViews.tsx
@@ -38,6 +38,12 @@ export default function CatCardWithViews({ cat, isOwnProfile }: CatCardWithViews
           )
         }
       />
+      {/* 非公開タグ */}
+      {cat.is_public === false && (
+        <div className="absolute bottom-[5.5rem] right-2 bg-gray-700 text-white text-xs px-2 py-0.5 rounded">
+          非公開
+        </div>
+      )}
       {/* ページビュー数の表示 */}
       <div className="mt-1 flex items-center justify-end text-gray-500 text-xs">
         <Eye className="h-3 w-3 mr-1" />

--- a/src/components/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch.tsx
@@ -1,0 +1,41 @@
+interface ToggleSwitchProps {
+  id: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label?: string;
+  disabled?: boolean;
+}
+
+export default function ToggleSwitch({ id, checked, onChange, label, disabled = false }: ToggleSwitchProps) {
+  return (
+    <div className="flex items-center">
+      <div className="relative">
+        <input
+          type="checkbox"
+          id={id}
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+          disabled={disabled}
+          className="sr-only"
+        />
+        <label
+          htmlFor={id}
+          className={`block w-12 h-6 rounded-full cursor-pointer transition-colors duration-200 ${
+            checked ? 'bg-gray-600' : 'bg-gray-300'
+          } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+        >
+          <span
+            className={`block w-5 h-5 bg-white rounded-full shadow transform transition-transform duration-200 translate-y-0.5 ${
+              checked ? 'translate-x-6' : 'translate-x-0.5'
+            }`}
+          />
+        </label>
+      </div>
+      {label && (
+        <span className={`ml-3 text-sm font-medium text-gray-700 ${disabled ? 'opacity-50' : ''}`}>
+          {label}
+        </span>
+      )}
+    </div>
+  );
+} 

--- a/src/pages/CatProfile.tsx
+++ b/src/pages/CatProfile.tsx
@@ -138,9 +138,9 @@ export default function CatProfile() {
         if (fetchError) throw fetchError;
         if (!data) throw new Error('猫が見つかりません');
 
-        // 猫が非公開で、かつ現在のユーザーが飼い主でない場合は404エラー
-        if (data.is_public === false && (!user || data.owner_id !== user.id)) {
-          throw new Error('この猫のプロフィールは存在しません');
+        // 猫が非公開の場合は404エラー
+        if (data.is_public === false) {
+          throw new Error('この猫ちゃんは非公開です🐈');
         }
 
         return data as CatWithOwner;

--- a/src/pages/EditCat.tsx
+++ b/src/pages/EditCat.tsx
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { ColorPickerModal } from '../components/ColorPickerModal';
 import ImageEditor from '../components/ImageEditor';
+import ToggleSwitch from '../components/ToggleSwitch';
 import { supabase } from '../lib/supabase';
 import { useAuthStore } from '../store/authStore';
 import {
@@ -33,6 +34,7 @@ interface CatFormData {
   gender?: string;
   background_color?: string;
   text_color?: string;
+  is_public?: boolean;
 }
 
 function sanitizeFileName(fileName: string): string {
@@ -61,6 +63,9 @@ export default function EditCat() {
   const [showTextColorPicker, setShowTextColorPicker] = useState(false);
   const [bgColor, setBgColor] = useState(defaultBackgroundColor);
   const [textColor, setTextColor] = useState(defaultTextColor);
+
+  // 公開/非公開のState
+  const [isPublic, setIsPublic] = useState(true);
 
   const {
     register,
@@ -108,11 +113,15 @@ export default function EditCat() {
         gender: cat.gender || '',
         background_color: cat.background_color || defaultBackgroundColor,
         text_color: cat.text_color || defaultTextColor,
+        is_public: cat.is_public !== undefined ? cat.is_public : true,
       });
 
       // 色の状態を初期化
       setBgColor(cat.background_color || defaultBackgroundColor);
       setTextColor(cat.text_color || defaultTextColor);
+
+      // 公開/非公開の状態を初期化
+      setIsPublic(cat.is_public !== undefined ? cat.is_public : true);
 
       // cat.image_urlが存在する場合、プレビューURLとして設定
       if (cat.image_url) {
@@ -218,6 +227,7 @@ export default function EditCat() {
           gender: data.gender || null,
           background_color: data.background_color,
           text_color: data.text_color,
+          is_public: data.is_public,
         })
         .eq('id', id);
 
@@ -530,6 +540,24 @@ export default function EditCat() {
                 className="block w-full px-3 py-2 border border-gray-300 rounded-lg
                   focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-transparent"
               />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">公開状態</label>
+              <div className="flex items-center">
+                <ToggleSwitch
+                  id="is_public_edit"
+                  checked={isPublic}
+                  onChange={(checked) => {
+                    setIsPublic(checked);
+                    setValue('is_public', checked);
+                  }}
+                  label={isPublic ? '公開' : '非公開'}
+                />
+              </div>
+              <p className="mt-1 text-sm text-gray-600">
+                公開すると他の人もプロフィールページを見ることができます
+              </p>
             </div>
 
             {/* カラーテーマ設定 */}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -18,6 +18,7 @@ export default function Home() {
       const { data, error } = await supabase
         .from('cats')
         .select('*')
+        .eq('is_public', true)
         .order('created_at', { ascending: false })
         .limit(6);
 

--- a/src/pages/RegisterCat.tsx
+++ b/src/pages/RegisterCat.tsx
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { ColorPickerModal } from '../components/ColorPickerModal';
 import ImageEditor from '../components/ImageEditor';
+import ToggleSwitch from '../components/ToggleSwitch';
 import { supabase } from '../lib/supabase';
 import { useAuthStore } from '../store/authStore';
 import {
@@ -33,6 +34,7 @@ interface CatFormData {
   gender?: string;
   background_color?: string;
   text_color?: string;
+  is_public?: boolean;
 }
 
 function sanitizeFileName(fileName: string): string {
@@ -72,6 +74,7 @@ export default function RegisterCat() {
       gender: '',
       background_color: defaultBackgroundColor,
       text_color: defaultTextColor,
+      is_public: true,
     },
   });
 
@@ -86,6 +89,9 @@ export default function RegisterCat() {
   const [showTextColorPicker, setShowTextColorPicker] = useState(false);
   const [bgColor, setBgColor] = useState(defaultBackgroundColor);
   const [textColor, setTextColor] = useState(defaultTextColor);
+
+  // 公開/非公開のState
+  const [isPublic, setIsPublic] = useState(true);
 
   // 背景色変更のハンドラー
   const handleBgColorChange = (color: string) => {
@@ -172,6 +178,7 @@ export default function RegisterCat() {
         gender: data.gender || null,
         background_color: data.background_color,
         text_color: data.text_color,
+        is_public: data.is_public,
       });
 
       if (error) throw error;
@@ -424,6 +431,24 @@ export default function RegisterCat() {
                 className="block w-full px-3 py-2 border border-gray-300 rounded-lg
                   focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-transparent"
               />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">公開状態</label>
+              <div className="flex items-center">
+                <ToggleSwitch
+                  id="is_public_register"
+                  checked={isPublic}
+                  onChange={(checked) => {
+                    setIsPublic(checked);
+                    setValue('is_public', checked);
+                  }}
+                  label={isPublic ? '公開' : '非公開'}
+                />
+              </div>
+              <p className="mt-1 text-sm text-gray-600">
+                公開すると他の人もプロフィールページを見ることができます
+              </p>
             </div>
 
             {/* カラーテーマ設定 */}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,7 @@ export interface Cat {
   gender?: string | null;
   background_color?: string;
   text_color?: string;
+  is_public?: boolean;
 }
 
 export interface Owner {

--- a/supabase/migrations/schema.sql
+++ b/supabase/migrations/schema.sql
@@ -77,6 +77,7 @@ create table public.cats (
     gender text,
     background_color text default '#FFFFFF',
     text_color text default '#000000',
+    is_public boolean default true not null,
     owner_id uuid references public.profiles(id) on delete cascade not null
 );
 


### PR DESCRIPTION
Closes #

## 概要
- 猫のプロフィールに公開/非公開機能を追加
- 非公開の猫は飼い主本人以外には表示されないように制御

## 変更内容
- データベーススキーマに`is_public`カラムを追加（デフォルト値: true）
- `ToggleSwitch`コンポーネントを新規作成
- `CatCardWithViews`に非公開タグの表示を追加
- `CatProfile`ページで非公開猫へのアクセス制御を実装
- `EditCat`・`RegisterCat`ページに公開状態設定UIを追加
- `Home`ページで公開猫のみを表示するように修正
- 関連するTypeScript型定義を更新

## 動作確認
- [x] 新規登録時に公開/非公開を切り替えられること
- [x] 編集時に公開/非公開を切り替えられること
- [x] 非公開猫のプロフィールページが飼い主以外には表示されないこと
- [x] 非公開猫に「非公開」タグが表示されること
- [x] ホームページで公開猫のみが表示されること
- [x] 飼い主本人は自分の非公開猫も表示されること

## 補足事項
- 既存の猫データは全て公開状態（is_public = true）として扱われる
- 非公開猫のプロフィールページにアクセスした場合は、猫ちゃんが非公開である旨のメッセージが表示される