### PR TITLE
Fix favorite query error handling

### DIFF
--- a/src/pages/CatProfile.tsx
+++ b/src/pages/CatProfile.tsx
@@ -177,14 +177,19 @@ export default function CatProfile() {
     queryFn: async () => {
       if (!user || !id) return false;
 
-      const { data } = await supabase
+      const { data, error } = await supabase
         .from('favorites')
         .select('id')
         .eq('cat_id', id)
         .eq('user_id', user.id)
-        .single();
+        .maybeSingle();
 
-      return !!data;
+      if (error) {
+        console.error('Error fetching favorite status:', error);
+        return false;
+      }
+
+      return Boolean(data);
     },
     enabled: !!user && !!id,
   });

--- a/src/pages/CatProfile.tsx
+++ b/src/pages/CatProfile.tsx
@@ -186,7 +186,7 @@ export default function CatProfile() {
 
       if (error) {
         console.error('Error fetching favorite status:', error);
-        return false;
+        throw error;
       }
 
       return Boolean(data);


### PR DESCRIPTION
## Summary
- prevent 406 error when checking if a cat is favorited

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872193020088329897ecea6e6d4340f