### PR TITLE
Fix clone path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 1. **リポジトリのクローン**
 ```bash
 git clone https://github.com/tsuchiya-yu/-nyanko.git
-cd -nyanko
+cd ./-nyanko
 ```
 
 2. **環境変数の設定**

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 1. **リポジトリのクローン**
 ```bash
 git clone https://github.com/tsuchiya-yu/-nyanko.git
-cd cat-link
+cd -nyanko
 ```
 
 2. **環境変数の設定**


### PR DESCRIPTION
## Summary
- replace repo directory name in README's setup instructions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687226c7b7c88329bd58f49aed669567