### PR TITLE
写真追加画面の上部にある「【猫の名前】の写真ギャラリー」リンクの遷移先を修正

### DIFF
--- a/src/pages/CatPhotos.tsx
+++ b/src/pages/CatPhotos.tsx
@@ -238,14 +238,14 @@ export default function CatPhotos() {
         </Helmet>
       )}
 
-      <h1 className="text-2xl font-bold mb-6">
+      <h1 className="text-2xl font-bold text-gray-800 mb-6 flex items-center">
         <Link
           to={`/cats/${id}`}
-          className="flex items-center text-gray-600 hover:text-gray-900 hover:underline transition-colors"
+          className="mr-2 text-gray-600 hover:text-gray-900 transition-colors"
         >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          {cat ? `${cat.name}のプロフィールページ` : 'プロフィールページ'}
+          <ArrowLeft className="h-5 w-5" />
         </Link>
+        {cat ? `${cat.name}の写真ギャラリー` : '写真ギャラリー'}
       </h1>
 
       <div className="bg-white rounded-lg shadow-md p-6 mb-4">

--- a/src/pages/CatPhotos.tsx
+++ b/src/pages/CatPhotos.tsx
@@ -244,7 +244,7 @@ export default function CatPhotos() {
           className="flex items-center text-gray-600 hover:text-gray-900 hover:underline transition-colors"
         >
           <ArrowLeft className="h-5 w-5 mr-2" />
-          {cat ? `${cat.name}の写真ギャラリー` : '写真ギャラリー'}
+          {cat ? `${cat.name}のプロフィールページ` : 'プロフィールページ'}
         </Link>
       </h1>
 

--- a/src/pages/CatPhotos.tsx
+++ b/src/pages/CatPhotos.tsx
@@ -245,7 +245,9 @@ export default function CatPhotos() {
         >
           <ArrowLeft className="h-5 w-5" />
         </Link>
-        {cat ? `${cat.name}の写真ギャラリー` : '写真ギャラリー'}
+        <Link to={`/cats/${id}`} className="hover:underline">
+          {cat ? `${cat.name}の写真ギャラリー` : '写真ギャラリー'}
+        </Link>
       </h1>
 
       <div className="bg-white rounded-lg shadow-md p-6 mb-4">

--- a/src/pages/CatPhotos.tsx
+++ b/src/pages/CatPhotos.tsx
@@ -238,7 +238,7 @@ export default function CatPhotos() {
         </Helmet>
       )}
 
-      <h1 className="text-2xl font-bold text-gray-800 mb-6">
+      <h1 className="text-2xl font-bold mb-6">
         <Link
           to={`/cats/${id}`}
           className="flex items-center text-gray-600 hover:text-gray-900 hover:underline transition-colors"

--- a/src/pages/CatPhotos.tsx
+++ b/src/pages/CatPhotos.tsx
@@ -238,14 +238,12 @@ export default function CatPhotos() {
         </Helmet>
       )}
 
-      <h1 className="text-2xl font-bold text-gray-800 mb-6 flex items-center">
+      <h1 className="text-2xl font-bold text-gray-800 mb-6">
         <Link
-          to={`/profile/${cat?.owner_id}`}
-          className="mr-2 text-gray-600 hover:text-gray-900 transition-colors"
+          to={`/cats/${id}`}
+          className="flex items-center text-gray-600 hover:text-gray-900 hover:underline transition-colors"
         >
-          <ArrowLeft className="h-5 w-5" />
-        </Link>
-        <Link to={`/cats/${id}`} className="hover:underline">
+          <ArrowLeft className="h-5 w-5 mr-2" />
           {cat ? `${cat.name}の写真ギャラリー` : '写真ギャラリー'}
         </Link>
       </h1>


### PR DESCRIPTION
Closes #65

## 概要
- update gallery title link on cat photos page

## 変更内容
- link "【猫の名前】の写真ギャラリー" to cat profile

## 動作確認
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68878a6ff2bc83298e583aa481c0a3f8