### PR TITLE
[バグ] lintのエラー修正(src/components/Layout/__tests__/Layout.test.tsx)

### DIFF
--- a/src/components/Layout/__tests__/Layout.test.tsx
+++ b/src/components/Layout/__tests__/Layout.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { MockedFunction } from 'vitest';
 
 import { useAuthStore } from '../../../store/authStore';
 import { renderWithProviders } from '../../../test/utils';
@@ -38,10 +39,11 @@ vi.mock('../../../lib/supabase', () => ({
 describe('Layoutコンポーネント', () => {
   const mockSetUser = vi.fn();
   const mockSignOut = vi.fn();
+  const useAuthStoreMock = useAuthStore as unknown as MockedFunction<typeof useAuthStore>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useAuthStore as any).mockReturnValue({
+    useAuthStoreMock.mockReturnValue({
       user: null,
       profile: null,
       setUser: mockSetUser,
@@ -63,7 +65,7 @@ describe('Layoutコンポーネント', () => {
   });
 
   it('ログインしている場合、マイページリンクが表示されること', () => {
-    (useAuthStore as any).mockReturnValue({
+    useAuthStoreMock.mockReturnValue({
       user: { id: 'user-1', email: 'test@example.com' },
       profile: { name: 'テストユーザー' },
       setUser: mockSetUser,
@@ -103,7 +105,7 @@ describe('Layoutコンポーネント', () => {
   });
 
   it('ログアウトボタンが存在しないことを確認', () => {
-    (useAuthStore as any).mockReturnValue({
+    useAuthStoreMock.mockReturnValue({
       user: { id: 'user-1', email: 'test@example.com' },
       profile: { name: 'テストユーザー' },
       setUser: mockSetUser,


### PR DESCRIPTION
Closes #73

## 概要

- Layoutのテストコードで発生していたESLintのno-explicit-any警告を解消

## 変更内容

- `src/components/Layout/__tests__/Layout.test.tsx` の `(useAuthStore as any)` を型安全な `MockedFunction<typeof useAuthStore>` に置き換え
- `vitest` の型 `MockedFunction` をimportし、モック関数の型付けを明確化

## 動作確認

- [ ] `make lint` で警告・エラーが発生しないこと
- [ ] `make test` でテストがグリーンであること

## 補足事項

- ローカル実行環境のNodeバージョン制約により、この環境では`npm`を直接実行できないため、CIまたはDocker経由の`make lint`/`make test`での確認をお願いします。
