### PR TITLE
[バグ] lintのエラー修正()

### DIFF
--- a/src/pages/RegisterCat.tsx
+++ b/src/pages/RegisterCat.tsx
@@ -98,7 +98,7 @@ export default function RegisterCat() {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [showImageEditor, setShowImageEditor] = useState(false);
   const [editingImage, setEditingImage] = useState<File | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSubmitting, _setIsSubmitting] = useState(false);
 
   // 色選択のState
   const [showBgColorPicker, setShowBgColorPicker] = useState(false);


### PR DESCRIPTION
Closes #79

## 概要

- RegisterCat.tsx の `@typescript-eslint/no-unused-vars` 警告を解消

## 変更内容

- 未使用の setter 名を規約どおり `^_` プレフィックスに変更
  - `setIsSubmitting` → `_setIsSubmitting`

## 動作確認

- [x] `make lint` 実行で当該警告が出ないことを確認
- [x] 登録ボタンの状態制御は `mutation.isPending` を利用しており、UI 仕様に変更がないことを確認

## 補足事項

- 他ファイルの警告（`no-explicit-any`, `no-console`, `react-hooks/exhaustive-deps` など）は別 Issue/PR にて対応予定
