### PR TITLE
fix: harden supabase rls policies for issue 86

### DIFF
--- a/supabase/migrations/20260227130000_harden_rls_policies.sql
+++ b/supabase/migrations/20260227130000_harden_rls_policies.sql
@@ -38,6 +38,17 @@ revoke insert, update, delete on table public.cache from anon, authenticated;
 -- -----------------------------------------------------------------------------
 -- news/columns: update permissions must be admin only via JWT claim.
 -- -----------------------------------------------------------------------------
+create or replace function public.is_admin()
+returns boolean
+language sql
+security definer
+set search_path = public
+as $$
+    select lower(coalesce(auth.jwt() ->> 'is_admin', 'false')) = 'true';
+$$;
+
+grant execute on function public.is_admin() to authenticated;
+
 alter table if exists public.news enable row level security;
 alter table if exists public.columns enable row level security;
 
@@ -47,34 +58,34 @@ drop policy if exists "Authenticated users can manage columns" on public.columns
 create policy "Admin can insert news"
     on public.news
     for insert
-    with check (lower(coalesce(auth.jwt() ->> 'is_admin', 'false')) = 'true');
+    with check (public.is_admin());
 
 create policy "Admin can update news"
     on public.news
     for update
-    using (lower(coalesce(auth.jwt() ->> 'is_admin', 'false')) = 'true')
-    with check (lower(coalesce(auth.jwt() ->> 'is_admin', 'false')) = 'true');
+    using (public.is_admin())
+    with check (public.is_admin());
 
 create policy "Admin can delete news"
     on public.news
     for delete
-    using (lower(coalesce(auth.jwt() ->> 'is_admin', 'false')) = 'true');
+    using (public.is_admin());
 
 create policy "Admin can insert columns"
     on public.columns
     for insert
-    with check (lower(coalesce(auth.jwt() ->> 'is_admin', 'false')) = 'true');
+    with check (public.is_admin());
 
 create policy "Admin can update columns"
     on public.columns
     for update
-    using (lower(coalesce(auth.jwt() ->> 'is_admin', 'false')) = 'true')
-    with check (lower(coalesce(auth.jwt() ->> 'is_admin', 'false')) = 'true');
+    using (public.is_admin())
+    with check (public.is_admin());
 
 create policy "Admin can delete columns"
     on public.columns
     for delete
-    using (lower(coalesce(auth.jwt() ->> 'is_admin', 'false')) = 'true');
+    using (public.is_admin());
 
 revoke insert, update, delete on table public.news from anon, authenticated;
 revoke insert, update, delete on table public.columns from anon, authenticated;


### PR DESCRIPTION
Closes #86

## 概要

- Supabase RLS/権限を最小権限化する migration を追加
- `cache` の anon/authenticated 更新系アクセスを遮断
- `news`/`columns` の更新系を JWT claim `is_admin=true` のみに制限
- `blog_posts`/`cat_info`/`gallery` は存在時のみ RLS + 権限遮断

## 変更内容

- `supabase/migrations/20260227130000_harden_rls_policies.sql` を追加
- `cache`:
  - 既存ポリシーを削除して service_role のみ許可する select/insert/update/delete policy を新設
  - `anon`/`authenticated` から `INSERT/UPDATE/DELETE` を `REVOKE`
- `news`/`columns`:
  - 既存の `Authenticated users can manage ...` policy を削除
  - `INSERT/UPDATE/DELETE` 用に admin 専用 policy（`auth.jwt()->>'is_admin'`）を新設
  - `anon`/`authenticated` から更新系権限を `REVOKE`
- `blog_posts`/`cat_info`/`gallery`:
  - `DO $$` で存在確認し、存在時のみ `enable row level security`
  - 既存 policy を全削除し、`anon`/`authenticated` への権限を `REVOKE ALL`

## 動作確認

- [x] `npm run lint`（エラーなし・既存 warning 18件）
- [x] `npm run test`（10 files / 50 tests passed）

## 補足事項

- ブランチ名は `codex/` プレフィックス推奨だが、ローカルに `codex` という既存ブランチがあり `codex/...` を作成できないため、`codex-issue-86-supabase-rls-cache-news-columns` を使用
