### PR TITLE
fix: GA4タグ認識を優先した計測設定へ修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     <!-- Content Security Policy -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://*.supabase.co http://127.0.0.1:54321; img-src 'self' data: blob: https://www.google-analytics.com https://www.googletagmanager.com https://*.supabase.co http://127.0.0.1:54321; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self';"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://analytics.google.com https://*.supabase.co http://127.0.0.1:54321; img-src 'self' data: blob: https://www.google-analytics.com https://*.google-analytics.com https://analytics.google.com https://www.googletagmanager.com https://*.supabase.co http://127.0.0.1:54321; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self';"
     />
 
     <title>CAT LINK - 愛猫のプロフィールページを簡単に作成・共有</title>
@@ -35,6 +35,19 @@
       name="keywords"
       content="猫, プロフィール, ペット, 写真, ギャラリー, 猫写真, 愛猫, 猫好き, 猫コミュニティ"
     />
+
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=%VITE_GA_TRACKING_ID%"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', '%VITE_GA_TRACKING_ID%', {
+        send_page_view: false,
+      });
+    </script>
 
     <!-- Google Search Console Verification -->
     <meta name="google-site-verification" content="%VITE_SEARCH_CONSOLE_VERIFICATION%" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,13 @@ export default function App() {
   // ルート変更時に画面トップにスクロールとページビュートラッキング
   useEffect(() => {
     window.scrollTo(0, 0);
-    trackPageView(location.pathname + location.search);
+    const pageViewTimerId = window.setTimeout(() => {
+      trackPageView(location.pathname + location.search);
+    }, 0);
+
+    return () => {
+      window.clearTimeout(pageViewTimerId);
+    };
   }, [location.pathname, location.search]);
 
   return (

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -3,75 +3,41 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 describe('analytics', () => {
   beforeEach(() => {
     vi.resetModules();
-    vi.useFakeTimers();
     vi.stubEnv('VITE_GA_TRACKING_ID', 'G-TEST123456');
     document.head.innerHTML = '';
     window.dataLayer = [];
     delete window.gtag;
-    Object.defineProperty(document, 'readyState', {
-      configurable: true,
-      value: 'loading',
-    });
   });
 
   afterEach(() => {
-    vi.runOnlyPendingTimers();
-    vi.useRealTimers();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
-    Object.defineProperty(document, 'readyState', {
-      configurable: true,
-      value: 'complete',
-    });
   });
 
-  it('defers loading gtag.js until after window load', async () => {
-    const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+  it('does not dynamically inject gtag.js or suppress GA storage', async () => {
     const { initGA } = await import('../analytics');
 
     initGA();
 
-    expect(window.dataLayer).toHaveLength(3);
-    expect(window.dataLayer[2]).toEqual([
-      'consent',
-      'default',
-      {
-        analytics_storage: 'denied',
-        ad_storage: 'denied',
-        functionality_storage: 'denied',
-        personalization_storage: 'denied',
-        security_storage: 'granted',
-        wait_for_update: 5000,
-      },
-    ]);
+    expect(window.dataLayer).toHaveLength(0);
+    expect(typeof window.gtag).toBe('function');
     expect(document.querySelector('script[src*="googletagmanager.com/gtag/js"]')).toBeNull();
-    expect(addEventListenerSpy).toHaveBeenCalledWith('load', expect.any(Function), { once: true });
-
-    window.dispatchEvent(new Event('load'));
-    vi.advanceTimersByTime(1000);
-
-    const script = document.querySelector<HTMLScriptElement>(
-      'script[src*="googletagmanager.com/gtag/js"]'
-    );
-
-    expect(script).not.toBeNull();
-    expect(script?.async).toBe(true);
-    expect(script?.src).toContain('id=G-TEST123456');
   });
 
-  it('queues page_view events before the script finishes loading', async () => {
+  it('queues page_view events for SPA route changes', async () => {
     const { initGA, trackPageView } = await import('../analytics');
 
     initGA();
     trackPageView('/cats/taro');
 
-    expect(window.dataLayer).toHaveLength(4);
+    expect(window.dataLayer).toHaveLength(1);
     expect(window.dataLayer.at(-1)).toEqual([
       'event',
       'page_view',
-      {
+      expect.objectContaining({
         page_path: '/cats/taro',
-      },
+        page_location: 'http://localhost:3000/cats/taro',
+      }),
     ]);
   });
 });

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -28,15 +28,16 @@ describe('analytics', () => {
     const { initGA, trackPageView } = await import('../analytics');
 
     initGA();
-    trackPageView('/cats/taro');
+    window.history.pushState(null, '', '/cats/taro?utm_source=test#profile');
+    trackPageView('/cats/taro?utm_source=test');
 
     expect(window.dataLayer).toHaveLength(1);
     expect(window.dataLayer.at(-1)).toEqual([
       'event',
       'page_view',
       expect.objectContaining({
-        page_path: '/cats/taro',
-        page_location: 'http://localhost:3000/cats/taro',
+        page_path: '/cats/taro?utm_source=test',
+        page_location: 'http://localhost:3000/cats/taro?utm_source=test#profile',
       }),
     ]);
   });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,13 +1,3 @@
-const GA_SCRIPT_ID = 'ga-gtag-script';
-const GA_LOAD_DELAY_MS = 1000;
-const CONSENT_UPDATE_DELAY_MS = 5000;
-
-let isInitialized = false;
-let consentTimerId: number | undefined;
-let scriptTimerId: number | undefined;
-
-const getTrackingId = (): string | undefined => import.meta.env.VITE_GA_TRACKING_ID;
-
 const ensureDataLayer = (): unknown[] => {
   window.dataLayer = window.dataLayer || [];
   return window.dataLayer;
@@ -27,82 +17,9 @@ const ensureGtag = (): ((...args: unknown[]) => void) => {
   return window.gtag;
 };
 
-const scheduleConsentUpdate = (gtag: (...args: unknown[]) => void): void => {
-  if (consentTimerId !== undefined) {
-    window.clearTimeout(consentTimerId);
-  }
-
-  consentTimerId = window.setTimeout(() => {
-    gtag('consent', 'update', {
-      analytics_storage: 'granted',
-    });
-  }, CONSENT_UPDATE_DELAY_MS);
-};
-
-const appendGtagScript = (trackingId: string): void => {
-  if (document.getElementById(GA_SCRIPT_ID)) {
-    return;
-  }
-
-  const script = document.createElement('script');
-  script.id = GA_SCRIPT_ID;
-  script.async = true;
-  script.src = `https://www.googletagmanager.com/gtag/js?id=${trackingId}`;
-  document.head.appendChild(script);
-};
-
-const scheduleDeferredScriptLoad = (trackingId: string): void => {
-  if (scriptTimerId !== undefined) {
-    window.clearTimeout(scriptTimerId);
-  }
-
-  scriptTimerId = window.setTimeout(() => {
-    appendGtagScript(trackingId);
-  }, GA_LOAD_DELAY_MS);
-};
-
 // Google Analytics初期化
 export const initGA = (): void => {
-  const trackingId = getTrackingId();
-
-  if (isInitialized || !trackingId) {
-    return;
-  }
-
-  const gtag = ensureGtag();
-  gtag('js', new Date());
-  gtag('config', trackingId, {
-    client_storage: 'none',
-    debug_mode: false,
-    anonymize_ip: true,
-    cookie_domain: 'none',
-    cookie_expires: 0,
-    cookie_flags: 'SameSite=None;Secure',
-    send_page_view: false,
-  });
-  gtag('consent', 'default', {
-    analytics_storage: 'denied',
-    ad_storage: 'denied',
-    functionality_storage: 'denied',
-    personalization_storage: 'denied',
-    security_storage: 'granted',
-    wait_for_update: CONSENT_UPDATE_DELAY_MS,
-  });
-  scheduleConsentUpdate(gtag);
-  isInitialized = true;
-
-  if (document.readyState === 'complete') {
-    scheduleDeferredScriptLoad(trackingId);
-    return;
-  }
-
-  window.addEventListener(
-    'load',
-    () => {
-      scheduleDeferredScriptLoad(trackingId);
-    },
-    { once: true }
-  );
+  ensureGtag();
 };
 
 // ページビューをトラッキング
@@ -110,6 +27,8 @@ export const trackPageView = (path: string): void => {
   if (window.gtag) {
     window.gtag('event', 'page_view', {
       page_path: path,
+      page_location: `${window.location.origin}${path}`,
+      page_title: document.title,
     });
   }
 };

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -24,13 +24,12 @@ export const initGA = (): void => {
 
 // ページビューをトラッキング
 export const trackPageView = (path: string): void => {
-  if (window.gtag) {
-    window.gtag('event', 'page_view', {
-      page_path: path,
-      page_location: window.location.href,
-      page_title: document.title,
-    });
-  }
+  const gtag = ensureGtag();
+  gtag('event', 'page_view', {
+    page_path: path,
+    page_location: window.location.href,
+    page_title: document.title,
+  });
 };
 
 // イベントをトラッキング
@@ -40,13 +39,12 @@ export const trackEvent = (
   label?: string,
   value?: number
 ): void => {
-  if (window.gtag) {
-    window.gtag('event', action, {
-      event_category: category,
-      event_label: label,
-      value: value,
-    });
-  }
+  const gtag = ensureGtag();
+  gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  });
 };
 
 // TypeScriptのためのgtagの型定義

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -27,7 +27,7 @@ export const trackPageView = (path: string): void => {
   if (window.gtag) {
     window.gtag('event', 'page_view', {
       page_path: path,
-      page_location: `${window.location.origin}${path}`,
+      page_location: window.location.href,
       page_title: document.title,
     });
   }


### PR DESCRIPTION
Closes #98

## 概要

- GA4管理画面でタグ認識されるように、静的な `gtag.js` asyncタグを復帰
- Cookie/Consent/動的遅延ロードによるGA4抑制設定を削除
- SPAルート変更時のページビュー送信は維持

## 変更内容

- `index.html` に `VITE_GA_TRACKING_ID` を使ったGA4公式寄りの初期化タグを追加
- `send_page_view: false` で初期ページビューの重複を避け、既存の `trackPageView` による送信に統一
- `src/lib/analytics.ts` から動的script挿入、Cookie無効化、Consent初期denied/自動granted更新を削除
- GA4収集先に必要なCSP許可を追加
- analyticsテストを新しい責務に合わせて更新

## 動作確認

- [x] `npm run lint`（既存warningのみ）
- [x] `npm run test`
- [x] `npm run build`
- [x] `npm run format:check`
- [x] `dist/index.html` に `G-H6E69FWBW8` の静的 `gtag.js` タグが出力されることを確認
- [x] `npm run preview -- --host 127.0.0.1 --port 4173` で `gtag/js` と `google-analytics.com/g/collect` の発火を確認

## 補足事項

- ローカルpreviewではSupabaseローカルAPI未起動のため `127.0.0.1:54321` への接続エラーが出ますが、今回のGA4修正とは無関係です。
- LighthouseのサードパーティCookie警告より、今回はGA4タグ認識・通常計測を優先しています。
- GA/GTMの `preconnect` は戻していません。
