### PR TITLE
fix: 公式Xリンクをcatnote_tokyoへ差し替え

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -291,7 +291,7 @@ export default function Layout({ children }: LayoutProps) {
                   </li>
                   <li>
                     <a
-                      href="https://x.com/CATLINK_PR"
+                      href="https://x.com/catnote_tokyo"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-base text-gray-600 hover:text-primary-600 flex items-center"


### PR DESCRIPTION
Closes #103

## 概要

- フッターの「公式X」リンクを移行先アカウントへ差し替えました。

## 変更内容

- `src/components/Layout.tsx` のリンク先を `https://x.com/CATLINK_PR` から `https://x.com/catnote_tokyo` に変更

## 動作確認

- [x] `npm run lint`
- [x] `npm run test`
- [x] ブラウザでトップページの「公式X」リンク href が `https://x.com/catnote_tokyo` であることを確認

## 補足事項

- lint は既存警告のみでエラーなし
- ブラウザ確認時のコンソールエラーはローカル Supabase 未起動および GA/CSP 由来で、今回変更とは無関係