### PR TITLE
fix: 猫プロフィールのSNS共有時に個別OGPを表示する

### DIFF
--- a/api/cat-profile.test.ts
+++ b/api/cat-profile.test.ts
@@ -14,11 +14,15 @@ describe('cat profile OGP function', () => {
   const originalSiteUrl = process.env.VITE_SITE_URL;
   const originalSupabaseUrl = process.env.VITE_SUPABASE_URL;
   const originalSupabaseKey = process.env.VITE_SUPABASE_ANON_KEY;
+  const originalBasicAuthUser = process.env.BASIC_AUTH_USER;
+  const originalBasicAuthPassword = process.env.BASIC_AUTH_PASSWORD;
 
   beforeEach(() => {
     process.env.VITE_SITE_URL = 'https://cat-link.catnote.tokyo';
     process.env.VITE_SUPABASE_URL = 'https://example.supabase.co';
     process.env.VITE_SUPABASE_ANON_KEY = 'public-anon-key';
+    delete process.env.BASIC_AUTH_USER;
+    delete process.env.BASIC_AUTH_PASSWORD;
   });
 
   afterEach(() => {
@@ -26,6 +30,16 @@ describe('cat profile OGP function', () => {
     process.env.VITE_SITE_URL = originalSiteUrl;
     process.env.VITE_SUPABASE_URL = originalSupabaseUrl;
     process.env.VITE_SUPABASE_ANON_KEY = originalSupabaseKey;
+    if (originalBasicAuthUser === undefined) {
+      delete process.env.BASIC_AUTH_USER;
+    } else {
+      process.env.BASIC_AUTH_USER = originalBasicAuthUser;
+    }
+    if (originalBasicAuthPassword === undefined) {
+      delete process.env.BASIC_AUTH_PASSWORD;
+    } else {
+      process.env.BASIC_AUTH_PASSWORD = originalBasicAuthPassword;
+    }
   });
 
   it('returns cat-specific metadata for a public cat', async () => {
@@ -62,6 +76,42 @@ describe('cat profile OGP function', () => {
     );
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls[1][0].toString()).toContain('is_public=eq.true');
+  });
+
+  it('does not forward bearer credentials to the HTML shell request', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(htmlShell, { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }));
+
+    await handler(
+      new Request('https://cat-link.catnote.tokyo/api/cat-profile?path=tsukushi', {
+        headers: { authorization: 'Bearer user-jwt' },
+      })
+    );
+
+    const shellRequestHeaders = new Headers(fetchMock.mock.calls[0][1]?.headers);
+    expect(shellRequestHeaders.has('authorization')).toBe(false);
+  });
+
+  it('forwards Basic credentials only when Basic Auth is enabled', async () => {
+    process.env.BASIC_AUTH_USER = 'preview-user';
+    process.env.BASIC_AUTH_PASSWORD = 'preview-password';
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(htmlShell, { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }));
+
+    await handler(
+      new Request('https://cat-link.catnote.tokyo/api/cat-profile?path=tsukushi', {
+        headers: { authorization: 'Basic cHJldmlldy11c2VyOnByZXZpZXctcGFzc3dvcmQ=' },
+      })
+    );
+
+    const shellRequestHeaders = new Headers(fetchMock.mock.calls[0][1]?.headers);
+    expect(shellRequestHeaders.get('authorization')).toBe(
+      'Basic cHJldmlldy11c2VyOnByZXZpZXctcGFzc3dvcmQ='
+    );
   });
 
   it('does not expose metadata for a missing or private cat', async () => {

--- a/api/cat-profile.test.ts
+++ b/api/cat-profile.test.ts
@@ -1,0 +1,102 @@
+import handler from './cat-profile';
+
+const htmlShell = `<!doctype html>
+<html>
+  <head>
+    <!-- ROUTE_META_START -->
+    <title>ねこプロフィール</title>
+    <!-- ROUTE_META_END -->
+  </head>
+  <body><div id="root"></div></body>
+</html>`;
+
+describe('cat profile OGP function', () => {
+  const originalSiteUrl = process.env.VITE_SITE_URL;
+  const originalSupabaseUrl = process.env.VITE_SUPABASE_URL;
+  const originalSupabaseKey = process.env.VITE_SUPABASE_ANON_KEY;
+
+  beforeEach(() => {
+    process.env.VITE_SITE_URL = 'https://cat-link.catnote.tokyo';
+    process.env.VITE_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.VITE_SUPABASE_ANON_KEY = 'public-anon-key';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env.VITE_SITE_URL = originalSiteUrl;
+    process.env.VITE_SUPABASE_URL = originalSupabaseUrl;
+    process.env.VITE_SUPABASE_ANON_KEY = originalSupabaseKey;
+  });
+
+  it('returns cat-specific metadata for a public cat', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(htmlShell, { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              name: 'つくし',
+              catchphrase: '元気いっぱい',
+              description: 'つくしの毎日です。',
+              image_url: 'https://example.com/tsukushi.jpg',
+              prof_path_id: 'tsukushi',
+            },
+          ]),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      );
+
+    const response = await handler(
+      new Request('https://cat-link.catnote.tokyo/api/cat-profile?path=tsukushi')
+    );
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('<title data-rh="true">つくしのプロフィール | ねこプロフィール</title>');
+    expect(html).toContain(
+      '<meta data-rh="true" property="og:image" content="https://example.com/tsukushi.jpg" />'
+    );
+    expect(html).toContain(
+      '<meta data-rh="true" name="twitter:title" content="つくしのプロフィール'
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0].toString()).toContain('is_public=eq.true');
+  });
+
+  it('does not expose metadata for a missing or private cat', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(htmlShell, { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+
+    const response = await handler(
+      new Request('https://cat-link.catnote.tokyo/api/cat-profile?path=private_cat')
+    );
+    const html = await response.text();
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('x-robots-tag')).toBe('noindex, nofollow');
+    expect(html).toContain('指定された猫プロフィールは存在しないか、非公開');
+    expect(html).not.toContain('private cat name');
+  });
+
+  it('keeps the SPA shell available when Supabase metadata fetching fails', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(htmlShell, { status: 200 }))
+      .mockResolvedValueOnce(new Response('upstream error', { status: 500 }));
+
+    const response = await handler(
+      new Request('https://cat-link.catnote.tokyo/api/cat-profile?path=tsukushi')
+    );
+
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain('<title data-rh="true">猫プロフィール | ねこプロフィール</title>');
+    expect(html).toContain('href="https://cat-link.catnote.tokyo/cats/tsukushi"');
+  });
+});

--- a/api/cat-profile.ts
+++ b/api/cat-profile.ts
@@ -32,8 +32,9 @@ async function fetchHtmlShell(request: Request): Promise<Response> {
   const shellUrl = new URL('/index.html', request.url);
   const headers = new Headers();
   const authorization = request.headers.get('authorization');
+  const basicAuthEnabled = Boolean(process.env.BASIC_AUTH_USER && process.env.BASIC_AUTH_PASSWORD);
 
-  if (authorization) {
+  if (basicAuthEnabled && authorization && /^Basic\s+\S+$/i.test(authorization)) {
     headers.set('authorization', authorization);
   }
 

--- a/api/cat-profile.ts
+++ b/api/cat-profile.ts
@@ -1,0 +1,107 @@
+import { fetchPublicCatMetadata } from '../src/lib/publicCatMetadata';
+import {
+  createCatProfileMetadata,
+  createFallbackCatMetadata,
+  createMissingCatMetadata,
+  injectRouteMetadata,
+  PROFILE_PATH_PATTERN,
+} from '../src/utils/catProfileMetadata';
+
+export const config = {
+  runtime: 'edge',
+};
+
+function getSiteOrigin(request: Request): string {
+  const configuredUrl = process.env.VITE_SITE_URL;
+
+  if (configuredUrl) {
+    try {
+      const url = new URL(configuredUrl);
+      if (url.protocol === 'http:' || url.protocol === 'https:') {
+        return url.origin;
+      }
+    } catch {
+      console.warn('VITE_SITE_URL is invalid. Falling back to the request origin.');
+    }
+  }
+
+  return new URL(request.url).origin;
+}
+
+async function fetchHtmlShell(request: Request): Promise<Response> {
+  const shellUrl = new URL('/index.html', request.url);
+  const headers = new Headers();
+  const authorization = request.headers.get('authorization');
+
+  if (authorization) {
+    headers.set('authorization', authorization);
+  }
+
+  const response = await fetch(shellUrl, { headers });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch index.html: ${response.status}`);
+  }
+
+  return response;
+}
+
+function createHtmlResponse(shellResponse: Response, html: string, status: number): Response {
+  const headers = new Headers(shellResponse.headers);
+  headers.delete('content-encoding');
+  headers.delete('content-length');
+  headers.delete('etag');
+  headers.delete('last-modified');
+  headers.set('content-type', 'text/html; charset=utf-8');
+
+  if (status === 404) {
+    headers.set('cache-control', 'no-store');
+    headers.set('x-robots-tag', 'noindex, nofollow');
+  } else {
+    headers.set('cache-control', 'public, max-age=0, s-maxage=300, stale-while-revalidate=3600');
+  }
+
+  return new Response(html, { status, headers });
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  const requestUrl = new URL(request.url);
+  const path = requestUrl.searchParams.get('path') ?? '';
+  const siteOrigin = getSiteOrigin(request);
+  const publicProfileUrl = new URL(`/cats/${encodeURIComponent(path)}`, siteOrigin).href;
+  const shellResponse = await fetchHtmlShell(request);
+  const htmlShell = await shellResponse.text();
+
+  if (!PROFILE_PATH_PATTERN.test(path)) {
+    const html = injectRouteMetadata(
+      htmlShell,
+      createMissingCatMetadata(publicProfileUrl, siteOrigin)
+    );
+    return createHtmlResponse(shellResponse, html, 404);
+  }
+
+  try {
+    const cat = await fetchPublicCatMetadata(path, {
+      supabaseUrl: process.env.VITE_SUPABASE_URL,
+      supabaseAnonKey: process.env.VITE_SUPABASE_ANON_KEY,
+    });
+
+    if (!cat) {
+      const html = injectRouteMetadata(
+        htmlShell,
+        createMissingCatMetadata(publicProfileUrl, siteOrigin)
+      );
+      return createHtmlResponse(shellResponse, html, 404);
+    }
+
+    const html = injectRouteMetadata(htmlShell, createCatProfileMetadata(cat, siteOrigin));
+    return createHtmlResponse(shellResponse, html, 200);
+  } catch (error) {
+    console.error('Failed to render cat profile metadata:', error);
+    const html = injectRouteMetadata(
+      htmlShell,
+      createFallbackCatMetadata(publicProfileUrl, siteOrigin)
+    );
+    return createHtmlResponse(shellResponse, html, 200);
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -92,6 +92,23 @@ export default [
     },
   },
   {
+    files: ['api/**/*.ts', 'middleware.ts', 'vite.config.ts'],
+    languageOptions: {
+      globals: {
+        atob: 'readonly',
+        process: 'readonly',
+      },
+    },
+  },
+  {
+    files: ['vite.config.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.node.json',
+      },
+    },
+  },
+  {
     files: ['**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}'],
     languageOptions: {
       globals: {

--- a/index.html
+++ b/index.html
@@ -26,11 +26,6 @@
       content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://analytics.google.com https://*.supabase.co http://127.0.0.1:54321; img-src 'self' data: blob: https://www.google-analytics.com https://*.google-analytics.com https://analytics.google.com https://www.googletagmanager.com https://*.supabase.co http://127.0.0.1:54321; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self';"
     />
 
-    <title>ねこプロフィール - 愛猫のプロフィールページを簡単に作成・共有</title>
-    <meta
-      name="description"
-      content="ねこプロフィール|愛猫のプロフィールページを簡単に作成・共有できるサービス。写真ギャラリーやSNS連携機能で、大切な思い出を残しましょう。"
-    />
     <meta
       name="keywords"
       content="猫, プロフィール, ペット, 写真, ギャラリー, 猫写真, 愛猫, 猫好き, 猫コミュニティ"
@@ -52,8 +47,19 @@
     <!-- Google Search Console Verification -->
     <meta name="google-site-verification" content="%VITE_SEARCH_CONSOLE_VERIFICATION%" />
 
+    <!-- ROUTE_META_START -->
+    <title>ねこプロフィール - 愛猫のプロフィールページを簡単に作成・共有</title>
+    <meta
+      name="description"
+      content="ねこプロフィール|愛猫のプロフィールページを簡単に作成・共有できるサービス。写真ギャラリーやSNS連携機能で、大切な思い出を残しましょう。"
+    />
+    <meta name="robots" content="index, follow" />
+
     <!-- OGP基本設定 -->
-    <meta property="og:title" content="ねこプロフィール - 愛猫のプロフィールページを簡単に作成・共有" />
+    <meta
+      property="og:title"
+      content="ねこプロフィール - 愛猫のプロフィールページを簡単に作成・共有"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://cat-link.catnote.tokyo/" />
     <meta property="og:image" content="https://cat-link.catnote.tokyo/images/ogp.png" />
@@ -66,19 +72,22 @@
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@cat_link_jp" />
-    <meta name="twitter:title" content="ねこプロフィール - 愛猫のプロフィールページを簡単に作成・共有" />
+    <meta name="twitter:site" content="@catnote_tokyo" />
+    <meta
+      name="twitter:title"
+      content="ねこプロフィール - 愛猫のプロフィールページを簡単に作成・共有"
+    />
     <meta
       name="twitter:description"
       content="愛猫のプロフィールページを簡単に作成・共有できるサービス。写真ギャラリーやSNS連携機能で、大切な思い出を残しましょう。"
     />
     <meta name="twitter:image" content="https://cat-link.catnote.tokyo/images/ogp.png" />
+    <!-- ROUTE_META_END -->
 
     <!-- その他のメタタグ -->
     <meta name="author" content="ねこプロフィール" />
     <meta name="application-name" content="ねこプロフィール" />
     <meta name="theme-color" content="#1f2937" />
-    <meta name="robots" content="index, follow" />
     <meta name="format-detection" content="telephone=no" />
 
     <!-- モバイル対応 -->

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint --config eslint.config.js \"src/**/*.{js,jsx,ts,tsx}\"",
-    "lint:fix": "eslint --config eslint.config.js \"src/**/*.{js,jsx,ts,tsx}\" --fix",
+    "lint": "eslint --config eslint.config.js \"src/**/*.{js,jsx,ts,tsx}\" \"api/**/*.{js,jsx,ts,tsx}\" middleware.ts vite.config.ts",
+    "lint:fix": "eslint --config eslint.config.js \"src/**/*.{js,jsx,ts,tsx}\" \"api/**/*.{js,jsx,ts,tsx}\" middleware.ts vite.config.ts --fix",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,css,md,json}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,css,md,json}\"",
     "preview": "vite preview",

--- a/src/lib/publicCatMetadata.ts
+++ b/src/lib/publicCatMetadata.ts
@@ -1,0 +1,35 @@
+import type { PublicCatMetadataSource } from '../utils/catProfileMetadata';
+
+interface PublicCatMetadataOptions {
+  supabaseUrl: string | undefined;
+  supabaseAnonKey: string | undefined;
+}
+
+export async function fetchPublicCatMetadata(
+  path: string,
+  { supabaseUrl, supabaseAnonKey }: PublicCatMetadataOptions
+): Promise<PublicCatMetadataSource | null> {
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error('Supabase credentials are not configured');
+  }
+
+  const endpoint = new URL('/rest/v1/cats', supabaseUrl);
+  endpoint.searchParams.set('select', 'name,catchphrase,description,image_url,prof_path_id');
+  endpoint.searchParams.set('prof_path_id', `eq.${path}`);
+  endpoint.searchParams.set('is_public', 'eq.true');
+  endpoint.searchParams.set('limit', '1');
+
+  const response = await fetch(endpoint, {
+    headers: {
+      apikey: supabaseAnonKey,
+      authorization: `Bearer ${supabaseAnonKey}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch cat metadata: ${response.status}`);
+  }
+
+  const cats = (await response.json()) as PublicCatMetadataSource[];
+  return cats[0] ?? null;
+}

--- a/src/pages/CatProfile.tsx
+++ b/src/pages/CatProfile.tsx
@@ -17,9 +17,10 @@ import { handleApiError } from '../lib/api';
 import { supabase } from '../lib/supabase';
 import { useAuthStore } from '../store/authStore';
 import { calculateAge } from '../utils/calculateAge';
+import { createCatProfileDescription, createCatProfileImageUrl } from '../utils/catProfileMetadata';
 import { defaultBackgroundColor, defaultTextColor } from '../utils/constants';
 import { paths } from '../utils/paths';
-import { absoluteUrl } from '../utils/url';
+import { absoluteUrl, getBaseUrl } from '../utils/url';
 
 interface CatWithOwner {
   id: string;
@@ -331,6 +332,8 @@ export default function CatProfile() {
 
   // データベースから取得した色を使用（設定されていない場合はデフォルト値）
   const textColor = cat.text_color || defaultTextColor;
+  const socialDescription = createCatProfileDescription(cat);
+  const socialImageUrl = createCatProfileImageUrl(cat.image_url, getBaseUrl());
 
   return (
     <div
@@ -340,10 +343,7 @@ export default function CatProfile() {
       {!path && <Navigate to={paths.home()} replace />}
       <Helmet>
         <title>{`${cat.name}のプロフィール | ねこプロフィール`}</title>
-        <meta
-          name="description"
-          content={`${cat.name}は${age?.toString() || ''}の${cat.breed}です。${cat.catchphrase ? cat.catchphrase : ''}${cat.description ? cat.description.substring(0, 100) + '...' : ''}`}
-        />
+        <meta name="description" content={socialDescription} />
         <meta
           name="keywords"
           content={`${cat.name}, ${cat.breed}, 猫, ペット, プロフィール, 写真`}
@@ -351,25 +351,13 @@ export default function CatProfile() {
         <meta property="og:title" content={`${cat.name}のプロフィール | ねこプロフィール`} />
         <meta property="og:type" content="profile" />
         <meta property="og:url" content={absoluteUrl(paths.catProfile(path))} />
-        <meta
-          property="og:image"
-          content={`${cat.image_url}?width=1200&height=630&resize=contain`}
-        />
-        <meta
-          property="og:description"
-          content={`${cat.name}は${age?.toString() || ''}の${cat.breed}です。${cat.catchphrase ? cat.catchphrase : ''}`}
-        />
+        <meta property="og:image" content={socialImageUrl} />
+        <meta property="og:description" content={socialDescription} />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:site" content="@catnote_tokyo" />
         <meta name="twitter:title" content={`${cat.name}のプロフィール | ねこプロフィール`} />
-        <meta
-          name="twitter:description"
-          content={`${cat.name}は${age?.toString() || ''}の${cat.breed}です。${cat.catchphrase ? cat.catchphrase : ''}`}
-        />
-        <meta
-          name="twitter:image"
-          content={`${cat.image_url}?width=1200&height=630&resize=contain`}
-        />
+        <meta name="twitter:description" content={socialDescription} />
+        <meta name="twitter:image" content={socialImageUrl} />
         <meta property="profile:first_name" content={cat.name} />
         <link rel="canonical" href={absoluteUrl(paths.catProfile(path))} />
         <script type="application/ld+json">

--- a/src/pages/CatProfile.tsx
+++ b/src/pages/CatProfile.tsx
@@ -359,6 +359,17 @@ export default function CatProfile() {
           property="og:description"
           content={`${cat.name}は${age?.toString() || ''}の${cat.breed}です。${cat.catchphrase ? cat.catchphrase : ''}`}
         />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content="@catnote_tokyo" />
+        <meta name="twitter:title" content={`${cat.name}のプロフィール | ねこプロフィール`} />
+        <meta
+          name="twitter:description"
+          content={`${cat.name}は${age?.toString() || ''}の${cat.breed}です。${cat.catchphrase ? cat.catchphrase : ''}`}
+        />
+        <meta
+          name="twitter:image"
+          content={`${cat.image_url}?width=1200&height=630&resize=contain`}
+        />
         <meta property="profile:first_name" content={cat.name} />
         <link rel="canonical" href={absoluteUrl(paths.catProfile(path))} />
         <script type="application/ld+json">

--- a/src/utils/__tests__/catProfileMetadata.test.ts
+++ b/src/utils/__tests__/catProfileMetadata.test.ts
@@ -1,4 +1,5 @@
 import {
+  createCatProfileDescription,
   createCatProfileMetadata,
   createFallbackCatMetadata,
   createMissingCatMetadata,
@@ -52,6 +53,18 @@ describe('catProfileMetadata', () => {
 
     expect(metadata).toContain('https://cat-link.catnote.tokyo/images/ogp.png');
     expect(metadata).not.toContain('javascript:');
+  });
+
+  it('truncates descriptions without splitting emoji surrogate pairs', () => {
+    const description = createCatProfileDescription({
+      name: 'ミケ',
+      catchphrase: null,
+      description: `${'a'.repeat(158)}🐈末尾`,
+    });
+
+    expect(description).toBe(`${'a'.repeat(158)}🐈…`);
+    expect(Array.from(description)).toHaveLength(160);
+    expect(description).not.toContain('\uFFFD');
   });
 
   it('replaces only the marked metadata block', () => {

--- a/src/utils/__tests__/catProfileMetadata.test.ts
+++ b/src/utils/__tests__/catProfileMetadata.test.ts
@@ -1,0 +1,86 @@
+import {
+  createCatProfileMetadata,
+  createFallbackCatMetadata,
+  createMissingCatMetadata,
+  injectRouteMetadata,
+} from '../catProfileMetadata';
+
+const htmlShell = `<!doctype html>
+<html>
+  <head>
+    <!-- ROUTE_META_START -->
+    <title>Default title</title>
+    <!-- ROUTE_META_END -->
+  </head>
+  <body><div id="root"></div></body>
+</html>`;
+
+describe('catProfileMetadata', () => {
+  it('creates escaped metadata for a public cat profile', () => {
+    const metadata = createCatProfileMetadata(
+      {
+        name: 'ミケ <script>',
+        catchphrase: '元気な "猫"',
+        description: '毎日楽しく暮らしています。',
+        image_url: 'https://example.com/cat image.jpg',
+        prof_path_id: 'mike_cat',
+      },
+      'https://cat-link.catnote.tokyo'
+    );
+
+    expect(metadata).toContain('<title data-rh="true">ミケ &lt;script&gt;のプロフィール');
+    expect(metadata).toContain('元気な &quot;猫&quot; 毎日楽しく暮らしています。');
+    expect(metadata).toContain('content="https://example.com/cat%20image.jpg"');
+    expect(metadata).toContain('href="https://cat-link.catnote.tokyo/cats/mike_cat"');
+    expect(metadata).toContain('<meta data-rh="true" property="og:type" content="profile" />');
+    expect(metadata).toContain(
+      '<meta data-rh="true" name="twitter:site" content="@catnote_tokyo" />'
+    );
+  });
+
+  it('uses the default OGP image when the profile image is unsafe', () => {
+    const metadata = createCatProfileMetadata(
+      {
+        name: 'ミケ',
+        catchphrase: null,
+        description: '',
+        image_url: 'javascript:alert(1)',
+        prof_path_id: 'mike',
+      },
+      'https://cat-link.catnote.tokyo'
+    );
+
+    expect(metadata).toContain('https://cat-link.catnote.tokyo/images/ogp.png');
+    expect(metadata).not.toContain('javascript:');
+  });
+
+  it('replaces only the marked metadata block', () => {
+    const metadata = createMissingCatMetadata(
+      'https://cat-link.catnote.tokyo/cats/missing',
+      'https://cat-link.catnote.tokyo'
+    );
+    const html = injectRouteMetadata(htmlShell, metadata);
+
+    expect(html).toContain('猫プロフィールが見つかりません');
+    expect(html).toContain('content="noindex, nofollow"');
+    expect(html).not.toContain('Default title');
+    expect(html).toContain('<body><div id="root"></div></body>');
+  });
+
+  it('keeps the requested URL when profile data is temporarily unavailable', () => {
+    const metadata = createFallbackCatMetadata(
+      'https://cat-link.catnote.tokyo/cats/tsukushi',
+      'https://cat-link.catnote.tokyo'
+    );
+
+    expect(metadata).toContain('href="https://cat-link.catnote.tokyo/cats/tsukushi"');
+    expect(metadata).toContain('content="index, follow"');
+    expect(metadata).toContain('https://cat-link.catnote.tokyo/images/ogp.png');
+  });
+
+  it('throws when the HTML shell does not contain metadata markers', () => {
+    expect(() => injectRouteMetadata('<html></html>', 'metadata')).toThrow(
+      'Route metadata markers were not found'
+    );
+  });
+});

--- a/src/utils/catProfileMetadata.ts
+++ b/src/utils/catProfileMetadata.ts
@@ -33,15 +33,25 @@ function escapeHtml(value: string): string {
 
 function normalizeDescription(value: string): string {
   const normalized = value.replace(/\s+/g, ' ').trim();
+  const characters = Array.from(normalized);
 
-  if (normalized.length <= MAX_DESCRIPTION_LENGTH) {
+  if (characters.length <= MAX_DESCRIPTION_LENGTH) {
     return normalized;
   }
 
-  return `${normalized.slice(0, MAX_DESCRIPTION_LENGTH - 1)}…`;
+  return `${characters.slice(0, MAX_DESCRIPTION_LENGTH - 1).join('')}…`;
 }
 
-function toHttpUrl(value: string | null, siteOrigin: string): string {
+export function createCatProfileDescription(
+  cat: Pick<PublicCatMetadataSource, 'name' | 'catchphrase' | 'description'>
+): string {
+  return normalizeDescription(
+    [cat.catchphrase, cat.description].filter(Boolean).join(' ') ||
+      `${cat.name}のプロフィールをご紹介します。`
+  );
+}
+
+export function createCatProfileImageUrl(value: string | null, siteOrigin: string): string {
   const fallbackUrl = new URL(DEFAULT_OGP_PATH, siteOrigin).href;
 
   if (!value) {
@@ -86,16 +96,13 @@ function renderRouteMetadata(metadata: RouteMetadata): string {
 
 export function createCatProfileMetadata(cat: PublicCatMetadataSource, siteOrigin: string): string {
   const canonicalUrl = new URL(`/cats/${encodeURIComponent(cat.prof_path_id)}`, siteOrigin).href;
-  const description = normalizeDescription(
-    [cat.catchphrase, cat.description].filter(Boolean).join(' ') ||
-      `${cat.name}のプロフィールをご紹介します。`
-  );
+  const description = createCatProfileDescription(cat);
 
   return renderRouteMetadata({
     title: `${cat.name}のプロフィール | ねこプロフィール`,
     description,
     canonicalUrl,
-    imageUrl: toHttpUrl(cat.image_url, siteOrigin),
+    imageUrl: createCatProfileImageUrl(cat.image_url, siteOrigin),
     type: 'profile',
     robots: 'index, follow',
   });

--- a/src/utils/catProfileMetadata.ts
+++ b/src/utils/catProfileMetadata.ts
@@ -1,0 +1,135 @@
+const ROUTE_META_START = '<!-- ROUTE_META_START -->';
+const ROUTE_META_END = '<!-- ROUTE_META_END -->';
+const DEFAULT_OGP_PATH = '/images/ogp.png';
+const MAX_DESCRIPTION_LENGTH = 160;
+
+export const PROFILE_PATH_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{1,48}[a-zA-Z0-9]$/;
+
+export interface PublicCatMetadataSource {
+  name: string;
+  catchphrase: string | null;
+  description: string;
+  image_url: string | null;
+  prof_path_id: string;
+}
+
+interface RouteMetadata {
+  title: string;
+  description: string;
+  canonicalUrl: string;
+  imageUrl: string;
+  type: 'profile' | 'website';
+  robots: 'index, follow' | 'noindex, nofollow';
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function normalizeDescription(value: string): string {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+
+  if (normalized.length <= MAX_DESCRIPTION_LENGTH) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, MAX_DESCRIPTION_LENGTH - 1)}…`;
+}
+
+function toHttpUrl(value: string | null, siteOrigin: string): string {
+  const fallbackUrl = new URL(DEFAULT_OGP_PATH, siteOrigin).href;
+
+  if (!value) {
+    return fallbackUrl;
+  }
+
+  try {
+    const url = new URL(value, siteOrigin);
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : fallbackUrl;
+  } catch {
+    return fallbackUrl;
+  }
+}
+
+function renderRouteMetadata(metadata: RouteMetadata): string {
+  const title = escapeHtml(metadata.title);
+  const description = escapeHtml(metadata.description);
+  const canonicalUrl = escapeHtml(metadata.canonicalUrl);
+  const imageUrl = escapeHtml(metadata.imageUrl);
+
+  return `${ROUTE_META_START}
+    <title data-rh="true">${title}</title>
+    <meta data-rh="true" name="description" content="${description}" />
+    <meta data-rh="true" name="robots" content="${metadata.robots}" />
+    <link data-rh="true" rel="canonical" href="${canonicalUrl}" />
+
+    <meta data-rh="true" property="og:title" content="${title}" />
+    <meta data-rh="true" property="og:type" content="${metadata.type}" />
+    <meta data-rh="true" property="og:url" content="${canonicalUrl}" />
+    <meta data-rh="true" property="og:image" content="${imageUrl}" />
+    <meta data-rh="true" property="og:site_name" content="ねこプロフィール" />
+    <meta data-rh="true" property="og:description" content="${description}" />
+    <meta data-rh="true" property="og:locale" content="ja_JP" />
+
+    <meta data-rh="true" name="twitter:card" content="summary_large_image" />
+    <meta data-rh="true" name="twitter:site" content="@catnote_tokyo" />
+    <meta data-rh="true" name="twitter:title" content="${title}" />
+    <meta data-rh="true" name="twitter:description" content="${description}" />
+    <meta data-rh="true" name="twitter:image" content="${imageUrl}" />
+    ${ROUTE_META_END}`;
+}
+
+export function createCatProfileMetadata(cat: PublicCatMetadataSource, siteOrigin: string): string {
+  const canonicalUrl = new URL(`/cats/${encodeURIComponent(cat.prof_path_id)}`, siteOrigin).href;
+  const description = normalizeDescription(
+    [cat.catchphrase, cat.description].filter(Boolean).join(' ') ||
+      `${cat.name}のプロフィールをご紹介します。`
+  );
+
+  return renderRouteMetadata({
+    title: `${cat.name}のプロフィール | ねこプロフィール`,
+    description,
+    canonicalUrl,
+    imageUrl: toHttpUrl(cat.image_url, siteOrigin),
+    type: 'profile',
+    robots: 'index, follow',
+  });
+}
+
+export function createMissingCatMetadata(requestUrl: string, siteOrigin: string): string {
+  return renderRouteMetadata({
+    title: '猫プロフィールが見つかりません | ねこプロフィール',
+    description: '指定された猫プロフィールは存在しないか、非公開になっています。',
+    canonicalUrl: requestUrl,
+    imageUrl: new URL(DEFAULT_OGP_PATH, siteOrigin).href,
+    type: 'website',
+    robots: 'noindex, nofollow',
+  });
+}
+
+export function createFallbackCatMetadata(requestUrl: string, siteOrigin: string): string {
+  return renderRouteMetadata({
+    title: '猫プロフィール | ねこプロフィール',
+    description: '愛猫のプロフィールや写真をご紹介します。',
+    canonicalUrl: requestUrl,
+    imageUrl: new URL(DEFAULT_OGP_PATH, siteOrigin).href,
+    type: 'profile',
+    robots: 'index, follow',
+  });
+}
+
+export function injectRouteMetadata(html: string, metadata: string): string {
+  const startIndex = html.indexOf(ROUTE_META_START);
+  const endIndex = html.indexOf(ROUTE_META_END);
+
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    throw new Error('Route metadata markers were not found in index.html');
+  }
+
+  return `${html.slice(0, startIndex)}${metadata}${html.slice(endIndex + ROUTE_META_END.length)}`;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
+    "types": ["vite/client", "node", "vitest/globals"],
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
@@ -22,7 +23,7 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "api/**/*", "middleware.ts"],
   "exclude": ["supabase/functions/**/*"],
   "references": [{ "path": "./tsconfig.node.json", "composite": true }]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,8 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
+  "rewrites": [
+    { "source": "/cats/:path", "destination": "/api/cat-profile?path=:path" },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
   "headers": [
     {
       "source": "/(.*)\\.js",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,88 @@
-import { defineConfig, loadEnv } from 'vite';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
 import react from '@vitejs/plugin-react';
+import { defineConfig, loadEnv, type Plugin } from 'vite';
+
+import { fetchPublicCatMetadata } from './src/lib/publicCatMetadata';
+import {
+  createCatProfileMetadata,
+  createFallbackCatMetadata,
+  createMissingCatMetadata,
+  injectRouteMetadata,
+  PROFILE_PATH_PATTERN,
+} from './src/utils/catProfileMetadata';
+
+function catProfileMetadataPlugin(env: Record<string, string>): Plugin {
+  return {
+    name: 'cat-profile-metadata',
+    configureServer(server) {
+      server.middlewares.use(async (request, response, next) => {
+        const requestUrl = request.url;
+
+        if (
+          !requestUrl ||
+          !new URL(requestUrl, 'http://localhost').pathname.match(/^\/cats\/[^/]+$/)
+        ) {
+          next();
+          return;
+        }
+
+        try {
+          const template = await readFile(resolve(process.cwd(), 'index.html'), 'utf8');
+          const html = await server.transformIndexHtml(requestUrl, template);
+          response.statusCode = 200;
+          response.setHeader('content-type', 'text/html; charset=utf-8');
+          response.end(html);
+        } catch (error) {
+          next(error as Error);
+        }
+      });
+    },
+    transformIndexHtml: {
+      order: 'pre',
+      async handler(html, context) {
+        const requestUrl = new URL(context.path, env.VITE_SITE_URL || 'http://localhost:5173');
+        const match = requestUrl.pathname.match(/^\/cats\/([^/]+)$/);
+
+        if (!match) {
+          return html;
+        }
+
+        let path: string;
+        try {
+          path = decodeURIComponent(match[1]);
+        } catch {
+          return injectRouteMetadata(
+            html,
+            createMissingCatMetadata(requestUrl.href, requestUrl.origin)
+          );
+        }
+        const siteOrigin = requestUrl.origin;
+        const profileUrl = new URL(`/cats/${encodeURIComponent(path)}`, siteOrigin).href;
+
+        if (!PROFILE_PATH_PATTERN.test(path)) {
+          return injectRouteMetadata(html, createMissingCatMetadata(profileUrl, siteOrigin));
+        }
+
+        try {
+          const cat = await fetchPublicCatMetadata(path, {
+            supabaseUrl: env.VITE_SUPABASE_URL,
+            supabaseAnonKey: env.VITE_SUPABASE_ANON_KEY,
+          });
+          const metadata = cat
+            ? createCatProfileMetadata(cat, siteOrigin)
+            : createMissingCatMetadata(profileUrl, siteOrigin);
+
+          return injectRouteMetadata(html, metadata);
+        } catch (error) {
+          console.warn('Failed to inject cat profile metadata in Vite dev server:', error);
+          return injectRouteMetadata(html, createFallbackCatMetadata(profileUrl, siteOrigin));
+        }
+      },
+    },
+  };
+}
 
 // https://vitejs.dev/config/
 export default ({ mode }: { mode: string }) => {
@@ -8,7 +91,7 @@ export default ({ mode }: { mode: string }) => {
 
   return defineConfig({
     base: '/',
-    plugins: [react()],
+    plugins: [react(), catProfileMetadataPlugin(env)],
     optimizeDeps: {
       exclude: ['lucide-react'],
     },
@@ -30,7 +113,7 @@ export default ({ mode }: { mode: string }) => {
     },
     // HTMLファイル内の%ENV_VAR%を置換
     experimental: {
-      renderBuiltUrl(filename, { hostType }) {
+      renderBuiltUrl(filename) {
         return filename;
       },
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,8 +14,13 @@ import {
 } from './src/utils/catProfileMetadata';
 
 function catProfileMetadataPlugin(env: Record<string, string>): Plugin {
+  let configRoot = process.cwd();
+
   return {
     name: 'cat-profile-metadata',
+    configResolved(config) {
+      configRoot = config.root;
+    },
     configureServer(server) {
       server.middlewares.use(async (request, response, next) => {
         const requestUrl = request.url;
@@ -29,7 +34,7 @@ function catProfileMetadataPlugin(env: Record<string, string>): Plugin {
         }
 
         try {
-          const template = await readFile(resolve(process.cwd(), 'index.html'), 'utf8');
+          const template = await readFile(resolve(configRoot, 'index.html'), 'utf8');
           const html = await server.transformIndexHtml(requestUrl, template);
           response.statusCode = 200;
           response.setHeader('content-type', 'text/html; charset=utf-8');


### PR DESCRIPTION
Closes #107

## 概要

- 猫プロフィールURLをSNS共有した際に、対象の猫固有の名前・画像・説明がOGP/Twitter Cardへ表示されるようにする
- JavaScriptを実行しないクローラーにも個別メタデータを返す

## 変更内容

- `/cats/:path` を動的OGP用Vercel Functionへrewrite
- Supabaseの公開猫だけを取得し、ビルド済みHTMLへOGP・Twitter Card・canonicalを注入
- 非公開・存在しない猫、画像未設定、Supabase取得失敗時のフォールバックを追加
- `data-rh`を付与し、React Helmet適用後のメタタグ重複を防止
- Vite開発サーバーでも同じメタデータを確認できるHTML変換を追加
- Functionとメタデータ生成処理のテストを追加

## 動作確認

- [x] `npm test`（60件成功）
- [x] `npm run lint`（エラー0件、既存警告14件）
- [x] `npm run build`
- [x] `curl`で初期HTMLに猫固有のtitle・OGP・Twitter Card・canonicalが含まれることを確認
- [x] ブラウザでプロフィール本文・共有モーダルが表示され、エラーoverlayとコンソールエラーがないことを確認
- [x] React Helmet適用後もOGP・Twitter Card・canonicalが各1件であることを確認

## 補足事項

- Vercel CLIが未認証のため、`vercel dev`での確認は未実施
- プロジェクト全体の`npx tsc --noEmit`には、本変更前から存在する型エラーが残っている
