### PR TITLE
feat: add quick profile analytics foundation

### DIFF
--- a/docs/QUICK_PROFILE_ANALYTICS.md
+++ b/docs/QUICK_PROFILE_ANALYTICS.md
@@ -1,0 +1,65 @@
+# 30秒体験 GA4計測仕様
+
+## 目的
+
+未登録でのプロフィール作成開始から、プレビュー、認証、公開、プロフィールカード共有までのファネルを計測する。
+
+「30秒」は、作成画面が操作可能になってから、写真と名前を満たしたプロフィールプレビューが初めて表示されるまでとする。
+
+## イベント
+
+| イベント名                       | 発火条件                                         | 重複防止                | パラメータ                             |
+| -------------------------------- | ------------------------------------------------ | ----------------------- | -------------------------------------- |
+| `quick_profile_create_start`     | 作成画面が操作可能になった                       | セッション内で最初の1回 | なし                                   |
+| `quick_profile_photo_selected`   | 有効な写真を初めて選択した                       | セッション内で最初の1回 | なし                                   |
+| `quick_profile_preview_ready`    | 写真と名前を満たしたプレビューが初めて表示された | セッション内で最初の1回 | `elapsed_time_ms`, `within_30_seconds` |
+| `quick_profile_auth_open`        | プレビューから認証を開始した                     | セッション内で最初の1回 | `auth_method`                          |
+| `quick_profile_auth_complete`    | 認証が完了した                                   | セッション内で最初の1回 | `auth_method`                          |
+| `quick_profile_publish_complete` | 猫プロフィールの保存と公開が完了した             | セッション内で最初の1回 | なし                                   |
+| `profile_card_download`          | 標準プロフィールカードの保存を実行した           | 利用者の操作ごと        | `card_format`                          |
+| `profile_card_share`             | カードの共有を実行した                           | 利用者の操作ごと        | `card_format`, `share_destination`     |
+
+## 許可値
+
+- `auth_method`: `register`, `login`
+- `card_format`: `standard_3_4`
+- `share_destination`: `native`, `x`, `line`, `instagram`, `copy_link`, `other`
+- `within_30_seconds`: `true`, `false`
+- `elapsed_time_ms`: 0以上の整数
+
+猫の名前、飼い主の名前、メールアドレス、プロフィールURL、自由入力文、画像URLは送信しない。
+
+## 実装方法
+
+`src/lib/quickProfileAnalytics.ts` のシングルトンを各画面から利用する。
+
+```ts
+quickProfileAnalytics.start();
+quickProfileAnalytics.trackPhotoSelected();
+quickProfileAnalytics.trackPreviewReady();
+quickProfileAnalytics.trackAuthOpen('register');
+quickProfileAnalytics.trackAuthComplete('register');
+quickProfileAnalytics.trackPublishComplete();
+quickProfileAnalytics.trackCardDownload();
+quickProfileAnalytics.trackCardShare('native');
+```
+
+ファネルの開始時刻と送信済みイベント名だけを `sessionStorage` に保持する。プロフィール入力値は保存しない。公開完了後に再び `start()` を呼ぶと新しい計測セッションを開始する。
+
+GA4またはWeb Storageが利用できない場合も、プロフィールの作成・公開・共有処理は継続する。
+
+## 後続ISSUEでの組み込み
+
+- #110: `create_start`, `photo_selected`, `preview_ready`
+- #111: `auth_open`, `auth_complete`, `publish_complete`
+- #113: `profile_card_download`, `profile_card_share`
+- #114: トップページCTAから作成画面へ遷移した場合も、作成画面側で `create_start` を発火する
+
+## GA4管理画面
+
+イベントの収集自体にカスタム定義は不要。探索レポートでパラメータを使用する場合は、GA4管理画面で以下を登録する。
+
+- カスタム指標: `elapsed_time_ms`（イベントスコープ、測定単位はミリ秒）
+- カスタムディメンション: `within_30_seconds`, `auth_method`, `card_format`, `share_destination`（イベントスコープ）
+
+公開完了を主要コンバージョンとして扱う場合は、`quick_profile_publish_complete`をキーイベントに設定する。

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -41,4 +41,33 @@ describe('analytics', () => {
       }),
     ]);
   });
+
+  it('queues structured events and removes undefined parameters', async () => {
+    const { trackEvent } = await import('../analytics');
+
+    trackEvent('quick_profile_preview_ready', {
+      elapsed_time_ms: 12_345,
+      optional_parameter: undefined,
+      within_30_seconds: true,
+    });
+
+    expect(window.dataLayer.at(-1)).toEqual([
+      'event',
+      'quick_profile_preview_ready',
+      {
+        elapsed_time_ms: 12_345,
+        within_30_seconds: true,
+      },
+    ]);
+  });
+
+  it('does not propagate errors from gtag', async () => {
+    const { trackEvent, trackPageView } = await import('../analytics');
+    window.gtag = vi.fn(() => {
+      throw new Error('analytics unavailable');
+    });
+
+    expect(() => trackEvent('quick_profile_create_start')).not.toThrow();
+    expect(() => trackPageView('/create')).not.toThrow();
+  });
 });

--- a/src/lib/__tests__/quickProfileAnalytics.test.ts
+++ b/src/lib/__tests__/quickProfileAnalytics.test.ts
@@ -23,7 +23,7 @@ describe('QuickProfileAnalytics', () => {
     analytics.start();
 
     expect(track).toHaveBeenCalledTimes(1);
-    expect(track).toHaveBeenCalledWith(QUICK_PROFILE_EVENT_NAMES.createStart);
+    expect(track).toHaveBeenCalledWith(QUICK_PROFILE_EVENT_NAMES.CREATE_START);
   });
 
   it('tracks the first ready preview with elapsed time and the 30-second result', () => {
@@ -33,7 +33,7 @@ describe('QuickProfileAnalytics', () => {
     analytics.trackPreviewReady();
     analytics.trackPreviewReady();
 
-    expect(track).toHaveBeenLastCalledWith(QUICK_PROFILE_EVENT_NAMES.previewReady, {
+    expect(track).toHaveBeenLastCalledWith(QUICK_PROFILE_EVENT_NAMES.PREVIEW_READY, {
       elapsed_time_ms: 29_500,
       within_30_seconds: true,
     });
@@ -47,7 +47,7 @@ describe('QuickProfileAnalytics', () => {
     analytics.trackPreviewReady();
 
     expect(track).toHaveBeenLastCalledWith(
-      QUICK_PROFILE_EVENT_NAMES.previewReady,
+      QUICK_PROFILE_EVENT_NAMES.PREVIEW_READY,
       expect.objectContaining({ within_30_seconds: false })
     );
   });
@@ -72,11 +72,11 @@ describe('QuickProfileAnalytics', () => {
     analytics.trackPublishComplete();
 
     expect(track.mock.calls).toEqual([
-      [QUICK_PROFILE_EVENT_NAMES.createStart],
-      [QUICK_PROFILE_EVENT_NAMES.photoSelected, undefined],
-      [QUICK_PROFILE_EVENT_NAMES.authOpen, { auth_method: 'register' }],
-      [QUICK_PROFILE_EVENT_NAMES.authComplete, { auth_method: 'register' }],
-      [QUICK_PROFILE_EVENT_NAMES.publishComplete, undefined],
+      [QUICK_PROFILE_EVENT_NAMES.CREATE_START],
+      [QUICK_PROFILE_EVENT_NAMES.PHOTO_SELECTED, undefined],
+      [QUICK_PROFILE_EVENT_NAMES.AUTH_OPEN, { auth_method: 'register' }],
+      [QUICK_PROFILE_EVENT_NAMES.AUTH_COMPLETE, { auth_method: 'register' }],
+      [QUICK_PROFILE_EVENT_NAMES.PUBLISH_COMPLETE, undefined],
     ]);
   });
 
@@ -87,7 +87,7 @@ describe('QuickProfileAnalytics', () => {
 
     analytics.start();
 
-    expect(track).toHaveBeenLastCalledWith(QUICK_PROFILE_EVENT_NAMES.createStart);
+    expect(track).toHaveBeenLastCalledWith(QUICK_PROFILE_EVENT_NAMES.CREATE_START);
     expect(track).toHaveBeenCalledTimes(3);
   });
 
@@ -95,10 +95,10 @@ describe('QuickProfileAnalytics', () => {
     analytics.trackCardDownload();
     analytics.trackCardShare('x');
 
-    expect(track).toHaveBeenNthCalledWith(1, QUICK_PROFILE_EVENT_NAMES.cardDownload, {
+    expect(track).toHaveBeenNthCalledWith(1, QUICK_PROFILE_EVENT_NAMES.CARD_DOWNLOAD, {
       card_format: 'standard_3_4',
     });
-    expect(track).toHaveBeenNthCalledWith(2, QUICK_PROFILE_EVENT_NAMES.cardShare, {
+    expect(track).toHaveBeenNthCalledWith(2, QUICK_PROFILE_EVENT_NAMES.CARD_SHARE, {
       card_format: 'standard_3_4',
       share_destination: 'x',
     });
@@ -124,8 +124,19 @@ describe('QuickProfileAnalytics', () => {
     storageBlockedAnalytics.start();
     storageBlockedAnalytics.trackPhotoSelected();
 
-    expect(track).toHaveBeenCalledWith(QUICK_PROFILE_EVENT_NAMES.createStart);
-    expect(track).toHaveBeenCalledWith(QUICK_PROFILE_EVENT_NAMES.photoSelected, undefined);
+    expect(track).toHaveBeenCalledWith(QUICK_PROFILE_EVENT_NAMES.CREATE_START);
+    expect(track).toHaveBeenCalledWith(QUICK_PROFILE_EVENT_NAMES.PHOTO_SELECTED, undefined);
     expect(() => storageBlockedAnalytics.reset()).not.toThrow();
   });
+
+  it.each(['null', '"invalid"', '123'])(
+    'starts a new measurement session when stored data is not an object: %s',
+    storedValue => {
+      sessionStorage.setItem('quick-profile-measurement-v1', storedValue);
+
+      analytics.start();
+
+      expect(track).toHaveBeenCalledWith(QUICK_PROFILE_EVENT_NAMES.CREATE_START);
+    }
+  );
 });

--- a/src/lib/__tests__/quickProfileAnalytics.test.ts
+++ b/src/lib/__tests__/quickProfileAnalytics.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { QUICK_PROFILE_EVENT_NAMES, QuickProfileAnalytics } from '../quickProfileAnalytics';
+
+describe('QuickProfileAnalytics', () => {
+  const track = vi.fn();
+  let now = 1_000_000;
+  let analytics: QuickProfileAnalytics;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    track.mockReset();
+    now = 1_000_000;
+    analytics = new QuickProfileAnalytics({
+      now: () => now,
+      storage: sessionStorage,
+      track,
+    });
+  });
+
+  it('tracks the start of a measurement session only once', () => {
+    analytics.start();
+    analytics.start();
+
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith(QUICK_PROFILE_EVENT_NAMES.createStart);
+  });
+
+  it('tracks the first ready preview with elapsed time and the 30-second result', () => {
+    analytics.start();
+    now += 29_500;
+
+    analytics.trackPreviewReady();
+    analytics.trackPreviewReady();
+
+    expect(track).toHaveBeenLastCalledWith(QUICK_PROFILE_EVENT_NAMES.previewReady, {
+      elapsed_time_ms: 29_500,
+      within_30_seconds: true,
+    });
+    expect(track).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports previews taking longer than 30 seconds', () => {
+    analytics.start();
+    now += 30_001;
+
+    analytics.trackPreviewReady();
+
+    expect(track).toHaveBeenLastCalledWith(
+      QUICK_PROFILE_EVENT_NAMES.previewReady,
+      expect.objectContaining({ within_30_seconds: false })
+    );
+  });
+
+  it('does not track funnel events before a session starts', () => {
+    analytics.trackPhotoSelected();
+    analytics.trackPreviewReady();
+    analytics.trackAuthOpen('register');
+    analytics.trackAuthComplete('register');
+    analytics.trackPublishComplete();
+
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it('tracks each funnel milestone once and keeps the authentication method non-personal', () => {
+    analytics.start();
+    analytics.trackPhotoSelected();
+    analytics.trackPhotoSelected();
+    analytics.trackAuthOpen('register');
+    analytics.trackAuthOpen('register');
+    analytics.trackAuthComplete('register');
+    analytics.trackPublishComplete();
+
+    expect(track.mock.calls).toEqual([
+      [QUICK_PROFILE_EVENT_NAMES.createStart],
+      [QUICK_PROFILE_EVENT_NAMES.photoSelected, undefined],
+      [QUICK_PROFILE_EVENT_NAMES.authOpen, { auth_method: 'register' }],
+      [QUICK_PROFILE_EVENT_NAMES.authComplete, { auth_method: 'register' }],
+      [QUICK_PROFILE_EVENT_NAMES.publishComplete, undefined],
+    ]);
+  });
+
+  it('starts a new session after the previous profile was published', () => {
+    analytics.start();
+    analytics.trackPublishComplete();
+    now += 5_000;
+
+    analytics.start();
+
+    expect(track).toHaveBeenLastCalledWith(QUICK_PROFILE_EVENT_NAMES.createStart);
+    expect(track).toHaveBeenCalledTimes(3);
+  });
+
+  it('tracks each card action with a constrained format and destination', () => {
+    analytics.trackCardDownload();
+    analytics.trackCardShare('x');
+
+    expect(track).toHaveBeenNthCalledWith(1, QUICK_PROFILE_EVENT_NAMES.cardDownload, {
+      card_format: 'standard_3_4',
+    });
+    expect(track).toHaveBeenNthCalledWith(2, QUICK_PROFILE_EVENT_NAMES.cardShare, {
+      card_format: 'standard_3_4',
+      share_destination: 'x',
+    });
+  });
+
+  it('continues without throwing when session storage is unavailable', () => {
+    const unavailableStorage = {
+      getItem: vi.fn(() => {
+        throw new Error('blocked');
+      }),
+      removeItem: vi.fn(() => {
+        throw new Error('blocked');
+      }),
+      setItem: vi.fn(() => {
+        throw new Error('blocked');
+      }),
+    };
+    const storageBlockedAnalytics = new QuickProfileAnalytics({
+      storage: unavailableStorage,
+      track,
+    });
+
+    storageBlockedAnalytics.start();
+    storageBlockedAnalytics.trackPhotoSelected();
+
+    expect(track).toHaveBeenCalledWith(QUICK_PROFILE_EVENT_NAMES.createStart);
+    expect(track).toHaveBeenCalledWith(QUICK_PROFILE_EVENT_NAMES.photoSelected, undefined);
+    expect(() => storageBlockedAnalytics.reset()).not.toThrow();
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -17,6 +17,18 @@ const ensureGtag = (): ((...args: unknown[]) => void) => {
   return window.gtag;
 };
 
+export type AnalyticsEventParameter = string | number | boolean;
+export type AnalyticsEventParameters = Record<string, AnalyticsEventParameter | undefined>;
+
+const removeUndefinedParameters = (
+  parameters: AnalyticsEventParameters
+): Record<string, AnalyticsEventParameter> =>
+  Object.fromEntries(
+    Object.entries(parameters).filter(
+      (entry): entry is [string, AnalyticsEventParameter] => entry[1] !== undefined
+    )
+  );
+
 // Google Analytics初期化
 export const initGA = (): void => {
   ensureGtag();
@@ -24,27 +36,26 @@ export const initGA = (): void => {
 
 // ページビューをトラッキング
 export const trackPageView = (path: string): void => {
-  const gtag = ensureGtag();
-  gtag('event', 'page_view', {
-    page_path: path,
-    page_location: window.location.href,
-    page_title: document.title,
-  });
+  try {
+    const gtag = ensureGtag();
+    gtag('event', 'page_view', {
+      page_path: path,
+      page_location: window.location.href,
+      page_title: document.title,
+    });
+  } catch {
+    // Analytics must never block navigation or rendering.
+  }
 };
 
 // イベントをトラッキング
-export const trackEvent = (
-  category: string,
-  action: string,
-  label?: string,
-  value?: number
-): void => {
-  const gtag = ensureGtag();
-  gtag('event', action, {
-    event_category: category,
-    event_label: label,
-    value: value,
-  });
+export const trackEvent = (action: string, parameters: AnalyticsEventParameters = {}): void => {
+  try {
+    const gtag = ensureGtag();
+    gtag('event', action, removeUndefinedParameters(parameters));
+  } catch {
+    // Analytics must never block the action being measured.
+  }
 };
 
 // TypeScriptのためのgtagの型定義

--- a/src/lib/quickProfileAnalytics.ts
+++ b/src/lib/quickProfileAnalytics.ts
@@ -1,0 +1,177 @@
+import { trackEvent, type AnalyticsEventParameters } from './analytics';
+
+export const QUICK_PROFILE_EVENT_NAMES = {
+  createStart: 'quick_profile_create_start',
+  photoSelected: 'quick_profile_photo_selected',
+  previewReady: 'quick_profile_preview_ready',
+  authOpen: 'quick_profile_auth_open',
+  authComplete: 'quick_profile_auth_complete',
+  publishComplete: 'quick_profile_publish_complete',
+  cardDownload: 'profile_card_download',
+  cardShare: 'profile_card_share',
+} as const;
+
+export type QuickProfileEventName =
+  (typeof QUICK_PROFILE_EVENT_NAMES)[keyof typeof QUICK_PROFILE_EVENT_NAMES];
+export type QuickProfileAuthMethod = 'login' | 'register';
+export type ProfileCardShareDestination =
+  | 'copy_link'
+  | 'instagram'
+  | 'line'
+  | 'native'
+  | 'other'
+  | 'x';
+
+interface QuickProfileMeasurementSession {
+  sentEvents: QuickProfileEventName[];
+  startedAt: number;
+}
+
+interface QuickProfileAnalyticsOptions {
+  now?: () => number;
+  storage?: Pick<Storage, 'getItem' | 'removeItem' | 'setItem'>;
+  track?: (action: string, parameters?: AnalyticsEventParameters) => void;
+}
+
+const STORAGE_KEY = 'quick-profile-measurement-v1';
+const THIRTY_SECONDS_IN_MS = 30_000;
+
+export class QuickProfileAnalytics {
+  private inMemorySession?: QuickProfileMeasurementSession;
+  private readonly now: () => number;
+  private readonly storage?: Pick<Storage, 'getItem' | 'removeItem' | 'setItem'>;
+  private readonly track: (action: string, parameters?: AnalyticsEventParameters) => void;
+
+  constructor({
+    now = Date.now,
+    storage = typeof window === 'undefined' ? undefined : window.sessionStorage,
+    track = trackEvent,
+  }: QuickProfileAnalyticsOptions = {}) {
+    this.now = now;
+    this.storage = storage;
+    this.track = track;
+  }
+
+  start(): void {
+    const currentSession = this.readSession();
+    if (
+      currentSession &&
+      !currentSession.sentEvents.includes(QUICK_PROFILE_EVENT_NAMES.publishComplete)
+    ) {
+      return;
+    }
+
+    const session: QuickProfileMeasurementSession = {
+      sentEvents: [QUICK_PROFILE_EVENT_NAMES.createStart],
+      startedAt: this.now(),
+    };
+
+    this.writeSession(session);
+    this.track(QUICK_PROFILE_EVENT_NAMES.createStart);
+  }
+
+  trackPhotoSelected(): void {
+    this.trackOnce(QUICK_PROFILE_EVENT_NAMES.photoSelected);
+  }
+
+  trackPreviewReady(): void {
+    const session = this.readSession();
+    if (!session || session.sentEvents.includes(QUICK_PROFILE_EVENT_NAMES.previewReady)) {
+      return;
+    }
+
+    const elapsedTimeMs = Math.max(0, Math.round(this.now() - session.startedAt));
+    this.markAsSent(session, QUICK_PROFILE_EVENT_NAMES.previewReady);
+    this.track(QUICK_PROFILE_EVENT_NAMES.previewReady, {
+      elapsed_time_ms: elapsedTimeMs,
+      within_30_seconds: elapsedTimeMs <= THIRTY_SECONDS_IN_MS,
+    });
+  }
+
+  trackAuthOpen(authMethod: QuickProfileAuthMethod): void {
+    this.trackOnce(QUICK_PROFILE_EVENT_NAMES.authOpen, { auth_method: authMethod });
+  }
+
+  trackAuthComplete(authMethod: QuickProfileAuthMethod): void {
+    this.trackOnce(QUICK_PROFILE_EVENT_NAMES.authComplete, { auth_method: authMethod });
+  }
+
+  trackPublishComplete(): void {
+    this.trackOnce(QUICK_PROFILE_EVENT_NAMES.publishComplete);
+  }
+
+  trackCardDownload(): void {
+    this.track(QUICK_PROFILE_EVENT_NAMES.cardDownload, { card_format: 'standard_3_4' });
+  }
+
+  trackCardShare(destination: ProfileCardShareDestination): void {
+    this.track(QUICK_PROFILE_EVENT_NAMES.cardShare, {
+      card_format: 'standard_3_4',
+      share_destination: destination,
+    });
+  }
+
+  reset(): void {
+    this.inMemorySession = undefined;
+
+    try {
+      this.storage?.removeItem(STORAGE_KEY);
+    } catch {
+      // Storage can be unavailable in privacy modes; measurement remains optional.
+    }
+  }
+
+  private trackOnce(eventName: QuickProfileEventName, parameters?: AnalyticsEventParameters): void {
+    const session = this.readSession();
+    if (!session || session.sentEvents.includes(eventName)) {
+      return;
+    }
+
+    this.markAsSent(session, eventName);
+    this.track(eventName, parameters);
+  }
+
+  private markAsSent(
+    session: QuickProfileMeasurementSession,
+    eventName: QuickProfileEventName
+  ): void {
+    session.sentEvents.push(eventName);
+    this.writeSession(session);
+  }
+
+  private readSession(): QuickProfileMeasurementSession | undefined {
+    try {
+      const storedValue = this.storage?.getItem(STORAGE_KEY);
+      if (!storedValue) return this.inMemorySession;
+
+      const parsedValue = JSON.parse(storedValue) as Partial<QuickProfileMeasurementSession>;
+      if (!Number.isFinite(parsedValue.startedAt) || !Array.isArray(parsedValue.sentEvents)) {
+        return undefined;
+      }
+
+      return {
+        sentEvents: parsedValue.sentEvents.filter((eventName): eventName is QuickProfileEventName =>
+          Object.values(QUICK_PROFILE_EVENT_NAMES).includes(eventName as QuickProfileEventName)
+        ),
+        startedAt: parsedValue.startedAt as number,
+      };
+    } catch {
+      return this.inMemorySession;
+    }
+  }
+
+  private writeSession(session: QuickProfileMeasurementSession): void {
+    this.inMemorySession = {
+      sentEvents: [...session.sentEvents],
+      startedAt: session.startedAt,
+    };
+
+    try {
+      this.storage?.setItem(STORAGE_KEY, JSON.stringify(session));
+    } catch {
+      // Storage can be unavailable in privacy modes; measurement remains optional.
+    }
+  }
+}
+
+export const quickProfileAnalytics = new QuickProfileAnalytics();

--- a/src/lib/quickProfileAnalytics.ts
+++ b/src/lib/quickProfileAnalytics.ts
@@ -1,14 +1,14 @@
 import { trackEvent, type AnalyticsEventParameters } from './analytics';
 
 export const QUICK_PROFILE_EVENT_NAMES = {
-  createStart: 'quick_profile_create_start',
-  photoSelected: 'quick_profile_photo_selected',
-  previewReady: 'quick_profile_preview_ready',
-  authOpen: 'quick_profile_auth_open',
-  authComplete: 'quick_profile_auth_complete',
-  publishComplete: 'quick_profile_publish_complete',
-  cardDownload: 'profile_card_download',
-  cardShare: 'profile_card_share',
+  CREATE_START: 'quick_profile_create_start',
+  PHOTO_SELECTED: 'quick_profile_photo_selected',
+  PREVIEW_READY: 'quick_profile_preview_ready',
+  AUTH_OPEN: 'quick_profile_auth_open',
+  AUTH_COMPLETE: 'quick_profile_auth_complete',
+  PUBLISH_COMPLETE: 'quick_profile_publish_complete',
+  CARD_DOWNLOAD: 'profile_card_download',
+  CARD_SHARE: 'profile_card_share',
 } as const;
 
 export type QuickProfileEventName =
@@ -56,56 +56,56 @@ export class QuickProfileAnalytics {
     const currentSession = this.readSession();
     if (
       currentSession &&
-      !currentSession.sentEvents.includes(QUICK_PROFILE_EVENT_NAMES.publishComplete)
+      !currentSession.sentEvents.includes(QUICK_PROFILE_EVENT_NAMES.PUBLISH_COMPLETE)
     ) {
       return;
     }
 
     const session: QuickProfileMeasurementSession = {
-      sentEvents: [QUICK_PROFILE_EVENT_NAMES.createStart],
+      sentEvents: [QUICK_PROFILE_EVENT_NAMES.CREATE_START],
       startedAt: this.now(),
     };
 
     this.writeSession(session);
-    this.track(QUICK_PROFILE_EVENT_NAMES.createStart);
+    this.track(QUICK_PROFILE_EVENT_NAMES.CREATE_START);
   }
 
   trackPhotoSelected(): void {
-    this.trackOnce(QUICK_PROFILE_EVENT_NAMES.photoSelected);
+    this.trackOnce(QUICK_PROFILE_EVENT_NAMES.PHOTO_SELECTED);
   }
 
   trackPreviewReady(): void {
     const session = this.readSession();
-    if (!session || session.sentEvents.includes(QUICK_PROFILE_EVENT_NAMES.previewReady)) {
+    if (!session || session.sentEvents.includes(QUICK_PROFILE_EVENT_NAMES.PREVIEW_READY)) {
       return;
     }
 
     const elapsedTimeMs = Math.max(0, Math.round(this.now() - session.startedAt));
-    this.markAsSent(session, QUICK_PROFILE_EVENT_NAMES.previewReady);
-    this.track(QUICK_PROFILE_EVENT_NAMES.previewReady, {
+    this.markAsSent(session, QUICK_PROFILE_EVENT_NAMES.PREVIEW_READY);
+    this.track(QUICK_PROFILE_EVENT_NAMES.PREVIEW_READY, {
       elapsed_time_ms: elapsedTimeMs,
       within_30_seconds: elapsedTimeMs <= THIRTY_SECONDS_IN_MS,
     });
   }
 
   trackAuthOpen(authMethod: QuickProfileAuthMethod): void {
-    this.trackOnce(QUICK_PROFILE_EVENT_NAMES.authOpen, { auth_method: authMethod });
+    this.trackOnce(QUICK_PROFILE_EVENT_NAMES.AUTH_OPEN, { auth_method: authMethod });
   }
 
   trackAuthComplete(authMethod: QuickProfileAuthMethod): void {
-    this.trackOnce(QUICK_PROFILE_EVENT_NAMES.authComplete, { auth_method: authMethod });
+    this.trackOnce(QUICK_PROFILE_EVENT_NAMES.AUTH_COMPLETE, { auth_method: authMethod });
   }
 
   trackPublishComplete(): void {
-    this.trackOnce(QUICK_PROFILE_EVENT_NAMES.publishComplete);
+    this.trackOnce(QUICK_PROFILE_EVENT_NAMES.PUBLISH_COMPLETE);
   }
 
   trackCardDownload(): void {
-    this.track(QUICK_PROFILE_EVENT_NAMES.cardDownload, { card_format: 'standard_3_4' });
+    this.track(QUICK_PROFILE_EVENT_NAMES.CARD_DOWNLOAD, { card_format: 'standard_3_4' });
   }
 
   trackCardShare(destination: ProfileCardShareDestination): void {
-    this.track(QUICK_PROFILE_EVENT_NAMES.cardShare, {
+    this.track(QUICK_PROFILE_EVENT_NAMES.CARD_SHARE, {
       card_format: 'standard_3_4',
       share_destination: destination,
     });
@@ -144,16 +144,25 @@ export class QuickProfileAnalytics {
       const storedValue = this.storage?.getItem(STORAGE_KEY);
       if (!storedValue) return this.inMemorySession;
 
-      const parsedValue = JSON.parse(storedValue) as Partial<QuickProfileMeasurementSession>;
-      if (!Number.isFinite(parsedValue.startedAt) || !Array.isArray(parsedValue.sentEvents)) {
+      const parsedValue: unknown = JSON.parse(storedValue);
+      if (!parsedValue || typeof parsedValue !== 'object') {
+        return undefined;
+      }
+
+      const sessionCandidate = parsedValue as Partial<QuickProfileMeasurementSession>;
+      if (
+        !Number.isFinite(sessionCandidate.startedAt) ||
+        !Array.isArray(sessionCandidate.sentEvents)
+      ) {
         return undefined;
       }
 
       return {
-        sentEvents: parsedValue.sentEvents.filter((eventName): eventName is QuickProfileEventName =>
-          Object.values(QUICK_PROFILE_EVENT_NAMES).includes(eventName as QuickProfileEventName)
+        sentEvents: sessionCandidate.sentEvents.filter(
+          (eventName): eventName is QuickProfileEventName =>
+            Object.values(QUICK_PROFILE_EVENT_NAMES).includes(eventName as QuickProfileEventName)
         ),
-        startedAt: parsedValue.startedAt as number,
+        startedAt: sessionCandidate.startedAt as number,
       };
     } catch {
       return this.inMemorySession;


### PR DESCRIPTION
Refs #115

## 概要

- 30秒体験のファネル計測に使うGA4イベント定義と送信基盤を追加
- 30秒以内プレビュー判定、認証方法、カード形式、共有先を非PIIパラメータとして扱えるように整理
- GA4管理画面で登録済みのカスタム定義と後続Issueでの組み込み箇所をドキュメント化

## 変更内容

- `trackEvent` をGA4イベント名 + 任意パラメータ形式へ拡張し、未定義値の除外と例外握りつぶしを追加
- `quickProfileAnalytics` を追加し、作成開始から公開完了までのセッション内一度だけのファネル計測を提供
- プロフィールカードの保存・共有イベントを追加
- 計測仕様、許可パラメータ、PII除外、後続Issueでの組み込み予定を `docs/QUICK_PROFILE_ANALYTICS.md` に記載
- analytics / quickProfileAnalytics のユニットテストを追加

## 動作確認

- [x] `npm test`
- [x] `npm run lint`（既存warning 14件、error 0件）
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `git diff --check`

## 補足事項

- このPRは #115 の計測基盤部分です。実際の発火箇所の組み込みとDebugView確認は #110 / #111 / #113 / #114 の実装後に行う想定です。
- GA4カスタム定義は管理画面で作成済みです: `within_30_seconds`, `auth_method`, `card_format`, `share_destination`, `elapsed_time_ms`。
- `quick_profile_publish_complete` のキーイベント化は、実イベントの発火確認後に行うのが安全です。
