### PR TITLE
feat: add quick profile preview flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ const EditCat = lazy(() => import('./pages/EditCat'));
 const News = lazy(() => import('./pages/News'));
 const NewsDetail = lazy(() => import('./pages/NewsDetail'));
 const Privacy = lazy(() => import('./pages/Privacy'));
+const QuickProfile = lazy(() => import('./pages/QuickProfile'));
 const RegisterCat = lazy(() => import('./pages/RegisterCat'));
 const Terms = lazy(() => import('./pages/Terms'));
 const UserProfile = lazy(() => import('./pages/UserProfile'));
@@ -87,6 +88,14 @@ export default function App() {
                 <ProtectedRoute>
                   <EditCat />
                 </ProtectedRoute>
+              </LazyRoute>
+            }
+          />
+          <Route
+            path={routePatterns.quickProfile}
+            element={
+              <LazyRoute>
+                <QuickProfile />
               </LazyRoute>
             }
           />

--- a/src/pages/QuickProfile.tsx
+++ b/src/pages/QuickProfile.tsx
@@ -1,0 +1,287 @@
+import { Camera, CheckCircle2, ImagePlus, Sparkles } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+
+import { useAuthModalStore } from '../components/Layout';
+import { quickProfileAnalytics } from '../lib/quickProfileAnalytics';
+import { defaultBackgroundColor, defaultTextColor } from '../utils/constants';
+import { paths } from '../utils/paths';
+import { absoluteUrl } from '../utils/url';
+
+const PERSONALITY_TAGS = ['甘えん坊', '元気いっぱい', 'のんびり', 'ツンデレ', '食いしん坊'];
+
+export default function QuickProfile() {
+  const [name, setName] = useState('');
+  const [catchphrase, setCatchphrase] = useState('');
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [photoUrl, setPhotoUrl] = useState<string | null>(null);
+  const [photoError, setPhotoError] = useState<string | null>(null);
+  const [isPhotoSelected, setIsPhotoSelected] = useState(false);
+  const [hasTrackedPreviewReady, setHasTrackedPreviewReady] = useState(false);
+  const { setIsOpen: setAuthModalOpen, setMode: setAuthModalMode } = useAuthModalStore();
+
+  const trimmedName = name.trim();
+  const hasRequiredInputs = Boolean(trimmedName && photoUrl);
+  const previewDescription = useMemo(() => {
+    if (catchphrase.trim()) return catchphrase.trim();
+    if (selectedTags.length > 0) return `${selectedTags.join('・')}な猫ちゃんです。`;
+    return '写真と名前だけで、まずはプロフィールの完成イメージを確認できます。';
+  }, [catchphrase, selectedTags]);
+
+  useEffect(() => {
+    quickProfileAnalytics.start();
+  }, []);
+
+  useEffect(() => {
+    if (hasRequiredInputs && !hasTrackedPreviewReady) {
+      quickProfileAnalytics.trackPreviewReady();
+      setHasTrackedPreviewReady(true);
+    }
+  }, [hasRequiredInputs, hasTrackedPreviewReady]);
+
+  useEffect(() => {
+    return () => {
+      if (photoUrl) {
+        URL.revokeObjectURL(photoUrl);
+      }
+    };
+  }, [photoUrl]);
+
+  const handlePhotoChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    setPhotoError(null);
+
+    if (!file) return;
+
+    if (!file.type.startsWith('image/')) {
+      setPhotoError('画像ファイルを選択してください。');
+      event.target.value = '';
+      return;
+    }
+
+    setPhotoUrl(currentUrl => {
+      if (currentUrl) {
+        URL.revokeObjectURL(currentUrl);
+      }
+      return URL.createObjectURL(file);
+    });
+
+    if (!isPhotoSelected) {
+      quickProfileAnalytics.trackPhotoSelected();
+      setIsPhotoSelected(true);
+    }
+  };
+
+  const handleTagToggle = (tag: string) => {
+    setSelectedTags(currentTags =>
+      currentTags.includes(tag)
+        ? currentTags.filter(currentTag => currentTag !== tag)
+        : [...currentTags, tag]
+    );
+  };
+
+  const handleOpenRegister = () => {
+    quickProfileAnalytics.trackAuthOpen('register');
+    setAuthModalMode('register');
+    setAuthModalOpen(true);
+  };
+
+  return (
+    <main className="bg-orange-50/50">
+      <Helmet>
+        <title>30秒で猫プロフィールをプレビュー | ねこプロフィール</title>
+        <meta
+          name="description"
+          content="会員登録の前に、猫の写真と名前だけでプロフィールの完成イメージを30秒で確認できます。"
+        />
+        <meta property="og:title" content="30秒で猫プロフィールをプレビュー | ねこプロフィール" />
+        <meta property="og:url" content={absoluteUrl(paths.quickProfile())} />
+        <meta
+          property="og:description"
+          content="会員登録の前に、猫の写真と名前だけでプロフィールの完成イメージを30秒で確認できます。"
+        />
+        <link rel="canonical" href={absoluteUrl(paths.quickProfile())} />
+      </Helmet>
+
+      <div className="mx-auto grid max-w-6xl gap-6 px-4 py-6 sm:px-6 lg:grid-cols-[minmax(0,0.9fr)_minmax(360px,1.1fr)] lg:py-10">
+        <section className="space-y-5">
+          <div>
+            <p className="text-sm font-semibold text-orange-700">30秒でプレビュー</p>
+            <h1 className="mt-2 text-2xl font-bold text-gray-900 sm:text-3xl">
+              写真と名前だけで、猫プロフィールの完成イメージを確認
+            </h1>
+            <p className="mt-3 text-sm leading-6 text-gray-700">
+              登録前に見た目を試せます。プレビュー段階では、猫データや画像は公開領域へ保存されません。
+            </p>
+          </div>
+
+          <div className="rounded-lg border border-orange-100 bg-white p-4 shadow-sm">
+            <div className="flex items-start gap-3">
+              <div className="rounded-full bg-orange-100 p-2 text-orange-700">
+                <Camera className="h-5 w-5" />
+              </div>
+              <div>
+                <h2 className="font-semibold text-gray-900">まずは2項目だけ</h2>
+                <p className="mt-1 text-sm text-gray-600">
+                  写真と名前を入れると右側に即時反映されます。
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-5 rounded-lg bg-white p-4 shadow-sm">
+            <div>
+              <label className="block text-sm font-medium text-gray-800" htmlFor="quick-photo">
+                猫の写真 <span className="text-red-600">必須</span>
+              </label>
+              <label className="mt-2 flex min-h-32 cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-orange-200 bg-orange-50/70 px-4 py-6 text-center transition-colors hover:border-orange-300 hover:bg-orange-50">
+                <ImagePlus className="h-8 w-8 text-orange-700" />
+                <span className="mt-2 text-sm font-medium text-gray-800">写真を選択</span>
+                <span className="mt-1 text-xs text-gray-500">
+                  この時点ではアップロードされません
+                </span>
+                <input
+                  id="quick-photo"
+                  type="file"
+                  accept="image/*"
+                  onChange={handlePhotoChange}
+                  className="sr-only"
+                />
+              </label>
+              {!photoUrl && (
+                <p className="mt-2 text-sm text-gray-600">プロフィール写真が未選択です。</p>
+              )}
+              {photoError && <p className="mt-2 text-sm text-red-600">{photoError}</p>}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-800" htmlFor="quick-name">
+                名前 <span className="text-red-600">必須</span>
+              </label>
+              <input
+                id="quick-name"
+                type="text"
+                value={name}
+                onChange={event => setName(event.target.value)}
+                placeholder="例: つくし"
+                maxLength={30}
+                className="mt-2 block w-full rounded-lg border border-gray-300 px-3 py-3 text-base focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200"
+              />
+              {!trimmedName && (
+                <p className="mt-2 text-sm text-gray-600">名前を入力してください。</p>
+              )}
+            </div>
+
+            <div>
+              <span className="block text-sm font-medium text-gray-800">性格タグ 任意</span>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {PERSONALITY_TAGS.map(tag => {
+                  const isSelected = selectedTags.includes(tag);
+                  return (
+                    <button
+                      key={tag}
+                      type="button"
+                      onClick={() => handleTagToggle(tag)}
+                      className={`rounded-full border px-3 py-1.5 text-sm transition-colors ${
+                        isSelected
+                          ? 'border-orange-500 bg-orange-100 text-orange-800'
+                          : 'border-gray-200 bg-white text-gray-700 hover:border-orange-300'
+                      }`}
+                      aria-pressed={isSelected}
+                    >
+                      {tag}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div>
+              <label
+                className="block text-sm font-medium text-gray-800"
+                htmlFor="quick-catchphrase"
+              >
+                ひとこと 任意
+              </label>
+              <input
+                id="quick-catchphrase"
+                type="text"
+                value={catchphrase}
+                onChange={event => setCatchphrase(event.target.value)}
+                placeholder="例: 今日も窓辺をパトロール中"
+                maxLength={80}
+                className="mt-2 block w-full rounded-lg border border-gray-300 px-3 py-3 text-base focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200"
+              />
+            </div>
+          </div>
+        </section>
+
+        <section className="lg:sticky lg:top-20 lg:self-start" aria-label="プロフィールプレビュー">
+          <div className="rounded-lg bg-white p-4 shadow-sm">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold text-gray-900">プロフィールプレビュー</p>
+                <p className="text-xs text-gray-500">公開ページに近い見た目で確認できます</p>
+              </div>
+              {hasRequiredInputs && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2.5 py-1 text-xs font-medium text-green-700">
+                  <CheckCircle2 className="h-3.5 w-3.5" />
+                  完成
+                </span>
+              )}
+            </div>
+
+            <div
+              className="overflow-hidden rounded-lg border border-gray-100 px-5 py-8 text-center"
+              style={{ backgroundColor: defaultBackgroundColor, color: defaultTextColor }}
+            >
+              <div className="mx-auto flex h-28 w-28 items-center justify-center overflow-hidden rounded-full bg-gray-100">
+                {photoUrl ? (
+                  <img
+                    src={photoUrl}
+                    alt={`${trimmedName || '猫'}のプレビュー`}
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <ImagePlus className="h-10 w-10 text-gray-400" aria-hidden="true" />
+                )}
+              </div>
+
+              <h2 className="mt-4 text-xl font-bold">{trimmedName || '猫ちゃんの名前'}</h2>
+              <p className="mt-1 text-sm text-gray-500">
+                {selectedTags.length > 0
+                  ? selectedTags.join(' | ')
+                  : '性格タグを選ぶとここに表示されます'}
+              </p>
+              <p className="mx-auto mt-4 max-w-sm whitespace-pre-line text-sm leading-6">
+                {previewDescription}
+              </p>
+            </div>
+
+            <div className="mt-4 rounded-lg border border-orange-100 bg-orange-50 p-4">
+              {hasRequiredInputs ? (
+                <>
+                  <div className="flex items-start gap-2 text-sm text-orange-900">
+                    <Sparkles className="mt-0.5 h-4 w-4 shrink-0" />
+                    <p>この内容をもとに、無料登録後ワンタップで公開へ進めるようになります。</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={handleOpenRegister}
+                    className="mt-4 w-full rounded-full bg-gray-900 px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
+                  >
+                    無料登録して公開へ進む
+                  </button>
+                </>
+              ) : (
+                <p className="text-sm text-gray-700">
+                  写真と名前を入れると、公開前の完成イメージを確認できます。
+                </p>
+              )}
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/__tests__/QuickProfile.test.tsx
+++ b/src/pages/__tests__/QuickProfile.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAuthModalStore } from '../../components/Layout';
+import { quickProfileAnalytics } from '../../lib/quickProfileAnalytics';
+import { renderWithProviders } from '../../test/utils';
+import QuickProfile from '../QuickProfile';
+
+vi.mock('../../lib/quickProfileAnalytics', () => ({
+  quickProfileAnalytics: {
+    start: vi.fn(),
+    trackPhotoSelected: vi.fn(),
+    trackPreviewReady: vi.fn(),
+    trackAuthOpen: vi.fn(),
+  },
+}));
+
+const mockedQuickProfileAnalytics = vi.mocked(quickProfileAnalytics);
+
+describe('QuickProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthModalStore.setState({ isOpen: false, mode: 'login' });
+    URL.createObjectURL = vi.fn(() => 'blob:quick-cat-photo');
+    URL.revokeObjectURL = vi.fn();
+  });
+
+  it('未登録でも写真と名前だけでプロフィールプレビューを表示する', () => {
+    renderWithProviders(<QuickProfile />, { initialEntries: ['/quick-profile'] });
+
+    expect(mockedQuickProfileAnalytics.start).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('heading', { name: /写真と名前だけで/ })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: '無料登録して公開へ進む' })
+    ).not.toBeInTheDocument();
+
+    const photoInput = screen.getByLabelText(/猫の写真/);
+    const photoFile = new File(['cat'], 'cat.png', { type: 'image/png' });
+    fireEvent.change(photoInput, { target: { files: [photoFile] } });
+    fireEvent.change(screen.getByLabelText(/名前/), { target: { value: 'つくし' } });
+
+    expect(screen.getByRole('heading', { name: 'つくし' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'つくしのプレビュー' })).toHaveAttribute(
+      'src',
+      'blob:quick-cat-photo'
+    );
+    expect(screen.getByRole('button', { name: '無料登録して公開へ進む' })).toBeInTheDocument();
+    expect(mockedQuickProfileAnalytics.trackPhotoSelected).toHaveBeenCalledTimes(1);
+    expect(mockedQuickProfileAnalytics.trackPreviewReady).toHaveBeenCalledTimes(1);
+  });
+
+  it('任意の性格タグとひとことをプレビューに反映する', () => {
+    renderWithProviders(<QuickProfile />, { initialEntries: ['/quick-profile'] });
+
+    fireEvent.click(screen.getByRole('button', { name: '甘えん坊' }));
+    fireEvent.change(screen.getByLabelText(/ひとこと/), {
+      target: { value: '今日も窓辺をパトロール中' },
+    });
+
+    expect(screen.getAllByText('甘えん坊')).toHaveLength(2);
+    expect(screen.getByText('今日も窓辺をパトロール中')).toBeInTheDocument();
+  });
+
+  it('公開CTAから登録モーダルを開き、認証開始を計測する', () => {
+    renderWithProviders(<QuickProfile />, { initialEntries: ['/quick-profile'] });
+
+    fireEvent.change(screen.getByLabelText(/猫の写真/), {
+      target: { files: [new File(['cat'], 'cat.png', { type: 'image/png' })] },
+    });
+    fireEvent.change(screen.getByLabelText(/名前/), { target: { value: 'つくし' } });
+    fireEvent.click(screen.getByRole('button', { name: '無料登録して公開へ進む' }));
+
+    expect(mockedQuickProfileAnalytics.trackAuthOpen).toHaveBeenCalledWith('register');
+    expect(useAuthModalStore.getState()).toMatchObject({ isOpen: true, mode: 'register' });
+  });
+
+  it('画像以外のファイルは受け付けない', () => {
+    renderWithProviders(<QuickProfile />, { initialEntries: ['/quick-profile'] });
+
+    fireEvent.change(screen.getByLabelText(/猫の写真/), {
+      target: { files: [new File(['text'], 'memo.txt', { type: 'text/plain' })] },
+    });
+
+    expect(screen.getByText('画像ファイルを選択してください。')).toBeInTheDocument();
+    expect(mockedQuickProfileAnalytics.trackPhotoSelected).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -5,6 +5,7 @@ export const routePatterns = {
   catProfile: '/cats/:path',
   editCat: '/cats/:id/edit',
   catPhotos: '/cats/:id/photos',
+  quickProfile: '/quick-profile',
   registerCat: '/register-cat',
   columns: '/columns',
   columnDetail: '/columns/:slug',
@@ -21,6 +22,7 @@ export const paths = {
     routePatterns.catProfile.replace(':path', encodeURIComponent(profPathId)),
   editCat: (catId: string) => routePatterns.editCat.replace(':id', encodeURIComponent(catId)),
   catPhotos: (catId: string) => routePatterns.catPhotos.replace(':id', encodeURIComponent(catId)),
+  quickProfile: () => routePatterns.quickProfile,
   registerCat: () => routePatterns.registerCat,
   userProfile: (userId: string) =>
     routePatterns.userProfile.replace(':id', encodeURIComponent(userId)),


### PR DESCRIPTION
Closes #110

## 概要

- 未ログインでもアクセスできる30秒プロフィール作成・プレビュー画面を追加
- 写真と名前だけで公開ページ風の完成イメージを即時確認できるようにした
- プレビュー完成後に無料登録へ進むCTAと、#115 のGA4計測イベント発火を組み込んだ

## 変更内容

- `/quick-profile` ルートとパス定義を追加
- `QuickProfile` ページを追加し、必須入力を「猫の写真」「名前」に限定
- 性格タグとひとことを任意入力としてプレビューへ反映
- プレビュー段階ではSupabase保存・画像アップロードを行わず、ローカルのObject URLのみを使用
- 写真未選択・名前未入力時の空状態と、画像以外のファイル選択時のバリデーションを追加
- プレビュー完成後に「無料登録して公開へ進む」CTAを表示し、登録モーダルを開く
- `quickProfileAnalytics` で `create_start` / `photo_selected` / `preview_ready` / `auth_open` を発火
- `QuickProfile` のコンポーネントテストを追加

## 動作確認

- [x] `npm test`
- [x] `npm run lint`（既存warning 14件、error 0件）
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `git diff --check`
- [x] ローカルブラウザで `http://127.0.0.1:5173/quick-profile` を開き、未ログイン表示・入力反映・コンソールエラーなしを確認

## 補足事項

- このPRは #115 の計測基盤PR #117 に依存しているため、baseを `feat/115-track-30-second-funnel` にしています。
- #117 マージ後に、このPRのbaseを `main` へ変更する想定です。
- 会員登録後のデータ引き継ぎと公開処理は #111 の対象として、このPRでは実装していません。
